### PR TITLE
Show appchooser when opening file for which there is no suitable app installed

### DIFF
--- a/app/src/main/java/com/omgodse/notally/activities/NotallyActivity.kt
+++ b/app/src/main/java/com/omgodse/notally/activities/NotallyActivity.kt
@@ -2,6 +2,7 @@ package com.omgodse.notally.activities
 
 import android.Manifest
 import android.app.Activity
+import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.content.res.ColorStateList
@@ -438,7 +439,11 @@ abstract class NotallyActivity(private val type: Type) : AppCompatActivity() {
                         setDataAndType(uri, fileAttachment.mimeType)
                         addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
                     }
-                startActivity(intent)
+                try {
+                    startActivity(intent)
+                } catch (e: ActivityNotFoundException) {
+                    startActivity(Intent.createChooser(intent, null))
+                }
             }) { fileAttachment ->
                 MaterialAlertDialogBuilder(this)
                     .setMessage(getString(R.string.delete_file, fileAttachment.originalName))


### PR DESCRIPTION
Fixes #11 

If the user tries to open an attached file for which there is no suitable app installed, he will be shown an empty `IntentChooser`:

[notally_open_file_no_app.webm](https://github.com/user-attachments/assets/fdd98c2e-0897-46f6-9d08-30d838daa54b)
