### PR TITLE
Fix ListItem.checked updates if toggled very fast

### DIFF
--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/ConfigureWidgetActivity.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/ConfigureWidgetActivity.kt
@@ -16,7 +16,7 @@ import com.philkes.notallyx.data.model.Header
 import com.philkes.notallyx.databinding.ActivityConfigureWidgetBinding
 import com.philkes.notallyx.presentation.view.main.BaseNoteAdapter
 import com.philkes.notallyx.presentation.view.misc.View
-import com.philkes.notallyx.presentation.view.note.listitem.ItemListener
+import com.philkes.notallyx.presentation.view.note.listitem.ListItemListener
 import com.philkes.notallyx.presentation.viewmodel.BaseNoteModel
 import com.philkes.notallyx.presentation.widget.WidgetProvider
 import com.philkes.notallyx.utils.IO
@@ -25,7 +25,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
-class ConfigureWidgetActivity : AppCompatActivity(), ItemListener {
+class ConfigureWidgetActivity : AppCompatActivity(), ListItemListener {
 
     private lateinit var adapter: BaseNoteAdapter
     private val id by lazy {

--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/main/MainActivity.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/main/MainActivity.kt
@@ -40,7 +40,7 @@ import com.philkes.notallyx.presentation.activity.note.EditListActivity
 import com.philkes.notallyx.presentation.activity.note.EditNoteActivity
 import com.philkes.notallyx.presentation.view.main.ColorAdapter
 import com.philkes.notallyx.presentation.view.misc.MenuDialog
-import com.philkes.notallyx.presentation.view.note.listitem.ItemListener
+import com.philkes.notallyx.presentation.view.note.listitem.ListItemListener
 import com.philkes.notallyx.presentation.viewmodel.BaseNoteModel
 import com.philkes.notallyx.utils.Operations
 import com.philkes.notallyx.utils.add
@@ -235,7 +235,7 @@ class MainActivity : AppCompatActivity() {
 
         val colorAdapter =
             ColorAdapter(
-                object : ItemListener {
+                object : ListItemListener {
                     override fun onClick(position: Int) {
                         dialog.dismiss()
                         val color = Color.entries[position]

--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/main/fragment/LabelsFragment.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/main/fragment/LabelsFragment.kt
@@ -22,11 +22,11 @@ import com.philkes.notallyx.databinding.FragmentNotesBinding
 import com.philkes.notallyx.presentation.view.Constants
 import com.philkes.notallyx.presentation.view.main.LabelAdapter
 import com.philkes.notallyx.presentation.view.misc.MenuDialog
-import com.philkes.notallyx.presentation.view.note.listitem.ItemListener
+import com.philkes.notallyx.presentation.view.note.listitem.ListItemListener
 import com.philkes.notallyx.presentation.viewmodel.BaseNoteModel
 import com.philkes.notallyx.utils.add
 
-class LabelsFragment : Fragment(), ItemListener {
+class LabelsFragment : Fragment(), ListItemListener {
 
     private var labelAdapter: LabelAdapter? = null
     private var binding: FragmentNotesBinding? = null

--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/main/fragment/NotallyFragment.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/main/fragment/NotallyFragment.kt
@@ -28,11 +28,11 @@ import com.philkes.notallyx.presentation.activity.note.EditNoteActivity
 import com.philkes.notallyx.presentation.view.Constants
 import com.philkes.notallyx.presentation.view.main.BaseNoteAdapter
 import com.philkes.notallyx.presentation.view.misc.View as ViewPref
-import com.philkes.notallyx.presentation.view.note.listitem.ItemListener
+import com.philkes.notallyx.presentation.view.note.listitem.ListItemListener
 import com.philkes.notallyx.presentation.viewmodel.BaseNoteModel
 import com.philkes.notallyx.utils.movedToResId
 
-abstract class NotallyFragment : Fragment(), ItemListener {
+abstract class NotallyFragment : Fragment(), ListItemListener {
 
     private var notesAdapter: BaseNoteAdapter? = null
     internal var binding: FragmentNotesBinding? = null

--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/note/EditActivity.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/note/EditActivity.kt
@@ -38,9 +38,9 @@ import com.philkes.notallyx.databinding.DialogProgressBinding
 import com.philkes.notallyx.presentation.view.Constants
 import com.philkes.notallyx.presentation.view.misc.TextSize
 import com.philkes.notallyx.presentation.view.note.ErrorAdapter
-import com.philkes.notallyx.presentation.view.note.PreviewFileAdapter
-import com.philkes.notallyx.presentation.view.note.PreviewImageAdapter
 import com.philkes.notallyx.presentation.view.note.audio.AudioAdapter
+import com.philkes.notallyx.presentation.view.note.preview.PreviewFileAdapter
+import com.philkes.notallyx.presentation.view.note.preview.PreviewImageAdapter
 import com.philkes.notallyx.presentation.viewmodel.NotallyModel
 import com.philkes.notallyx.presentation.widget.WidgetProvider
 import com.philkes.notallyx.utils.FileError

--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/note/EditListActivity.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/note/EditListActivity.kt
@@ -7,8 +7,8 @@ import com.philkes.notallyx.Preferences
 import com.philkes.notallyx.R
 import com.philkes.notallyx.data.model.Type
 import com.philkes.notallyx.presentation.view.misc.ListItemSorting
+import com.philkes.notallyx.presentation.view.note.listitem.ListItemAdapter
 import com.philkes.notallyx.presentation.view.note.listitem.ListManager
-import com.philkes.notallyx.presentation.view.note.listitem.MakeListAdapter
 import com.philkes.notallyx.presentation.view.note.listitem.sorting.ListItemNoSortCallback
 import com.philkes.notallyx.presentation.view.note.listitem.sorting.ListItemSortedByCheckedCallback
 import com.philkes.notallyx.presentation.view.note.listitem.sorting.ListItemSortedList
@@ -20,7 +20,7 @@ import com.philkes.notallyx.utils.setOnNextAction
 
 class EditListActivity : EditActivity(Type.LIST) {
 
-    private lateinit var adapter: MakeListAdapter
+    private lateinit var adapter: ListItemAdapter
     private lateinit var items: ListItemSortedList
 
     private lateinit var listManager: ListManager
@@ -94,7 +94,7 @@ class EditListActivity : EditActivity(Type.LIST) {
                 getSystemService(INPUT_METHOD_SERVICE) as InputMethodManager,
             )
         adapter =
-            MakeListAdapter(
+            ListItemAdapter(
                 model.textSize,
                 elevation,
                 Preferences.getInstance(application),

--- a/app/src/main/java/com/philkes/notallyx/presentation/view/main/BaseNoteAdapter.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/view/main/BaseNoteAdapter.kt
@@ -16,7 +16,7 @@ import com.philkes.notallyx.presentation.view.main.sorting.BaseNoteTitleSort
 import com.philkes.notallyx.presentation.view.misc.NotesSorting.autoSortByModifiedDate
 import com.philkes.notallyx.presentation.view.misc.NotesSorting.autoSortByTitle
 import com.philkes.notallyx.presentation.view.misc.SortDirection
-import com.philkes.notallyx.presentation.view.note.listitem.ItemListener
+import com.philkes.notallyx.presentation.view.note.listitem.ListItemListener
 import java.io.File
 
 class BaseNoteAdapter(
@@ -27,7 +27,7 @@ class BaseNoteAdapter(
     private val maxLines: Int,
     private val maxTitle: Int,
     private val imageRoot: File?,
-    private val listener: ItemListener,
+    private val listener: ListItemListener,
 ) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
 
     private var list =

--- a/app/src/main/java/com/philkes/notallyx/presentation/view/main/BaseNoteVH.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/view/main/BaseNoteVH.kt
@@ -25,7 +25,7 @@ import com.philkes.notallyx.data.model.SpanRepresentation
 import com.philkes.notallyx.data.model.Type
 import com.philkes.notallyx.databinding.RecyclerBaseNoteBinding
 import com.philkes.notallyx.presentation.view.misc.TextSize
-import com.philkes.notallyx.presentation.view.note.listitem.ItemListener
+import com.philkes.notallyx.presentation.view.note.listitem.ListItemListener
 import com.philkes.notallyx.utils.Operations
 import com.philkes.notallyx.utils.applySpans
 import com.philkes.notallyx.utils.displayFormattedTimestamp
@@ -40,7 +40,7 @@ class BaseNoteVH(
     private val maxItems: Int,
     maxLines: Int,
     maxTitle: Int,
-    listener: ItemListener,
+    listener: ListItemListener,
 ) : RecyclerView.ViewHolder(binding.root) {
 
     init {

--- a/app/src/main/java/com/philkes/notallyx/presentation/view/main/ColorAdapter.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/view/main/ColorAdapter.kt
@@ -5,9 +5,9 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import com.philkes.notallyx.data.model.Color
 import com.philkes.notallyx.databinding.RecyclerColorBinding
-import com.philkes.notallyx.presentation.view.note.listitem.ItemListener
+import com.philkes.notallyx.presentation.view.note.listitem.ListItemListener
 
-class ColorAdapter(private val listener: ItemListener) : RecyclerView.Adapter<ColorVH>() {
+class ColorAdapter(private val listener: ListItemListener) : RecyclerView.Adapter<ColorVH>() {
 
     private val colors = Color.values()
 

--- a/app/src/main/java/com/philkes/notallyx/presentation/view/main/ColorVH.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/view/main/ColorVH.kt
@@ -3,10 +3,10 @@ package com.philkes.notallyx.presentation.view.main
 import androidx.recyclerview.widget.RecyclerView
 import com.philkes.notallyx.data.model.Color
 import com.philkes.notallyx.databinding.RecyclerColorBinding
-import com.philkes.notallyx.presentation.view.note.listitem.ItemListener
+import com.philkes.notallyx.presentation.view.note.listitem.ListItemListener
 import com.philkes.notallyx.utils.Operations
 
-class ColorVH(private val binding: RecyclerColorBinding, listener: ItemListener) :
+class ColorVH(private val binding: RecyclerColorBinding, listener: ListItemListener) :
     RecyclerView.ViewHolder(binding.root) {
 
     init {

--- a/app/src/main/java/com/philkes/notallyx/presentation/view/main/LabelAdapter.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/view/main/LabelAdapter.kt
@@ -5,9 +5,9 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.ListAdapter
 import com.philkes.notallyx.databinding.RecyclerLabelBinding
 import com.philkes.notallyx.presentation.view.misc.StringDiffCallback
-import com.philkes.notallyx.presentation.view.note.listitem.ItemListener
+import com.philkes.notallyx.presentation.view.note.listitem.ListItemListener
 
-class LabelAdapter(private val listener: ItemListener) :
+class LabelAdapter(private val listener: ListItemListener) :
     ListAdapter<String, LabelVH>(StringDiffCallback()) {
 
     override fun onBindViewHolder(holder: LabelVH, position: Int) {

--- a/app/src/main/java/com/philkes/notallyx/presentation/view/main/LabelVH.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/view/main/LabelVH.kt
@@ -2,9 +2,9 @@ package com.philkes.notallyx.presentation.view.main
 
 import androidx.recyclerview.widget.RecyclerView
 import com.philkes.notallyx.databinding.RecyclerLabelBinding
-import com.philkes.notallyx.presentation.view.note.listitem.ItemListener
+import com.philkes.notallyx.presentation.view.note.listitem.ListItemListener
 
-class LabelVH(private val binding: RecyclerLabelBinding, listener: ItemListener) :
+class LabelVH(private val binding: RecyclerLabelBinding, listener: ListItemListener) :
     RecyclerView.ViewHolder(binding.root) {
 
     init {

--- a/app/src/main/java/com/philkes/notallyx/presentation/view/note/listitem/ListItemAdapter.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/view/note/listitem/ListItemAdapter.kt
@@ -8,15 +8,15 @@ import com.philkes.notallyx.Preferences
 import com.philkes.notallyx.databinding.RecyclerListItemBinding
 import com.philkes.notallyx.presentation.view.note.listitem.sorting.ListItemSortedList
 
-class MakeListAdapter(
+class ListItemAdapter(
     private val textSize: String,
     elevation: Float,
     private val preferences: Preferences,
     private val listManager: ListManager,
-) : RecyclerView.Adapter<MakeListVH>() {
+) : RecyclerView.Adapter<ListItemVH>() {
 
     private lateinit var list: ListItemSortedList
-    private val callback = DragCallback(elevation, listManager)
+    private val callback = ListItemDragCallback(elevation, listManager)
     private val touchHelper = ItemTouchHelper(callback)
 
     override fun onAttachedToRecyclerView(recyclerView: RecyclerView) {
@@ -25,16 +25,16 @@ class MakeListAdapter(
 
     override fun getItemCount() = list.size()
 
-    override fun onBindViewHolder(holder: MakeListVH, position: Int) {
+    override fun onBindViewHolder(holder: ListItemVH, position: Int) {
         val item = list[position]
         holder.bind(item, position == 0, preferences.listItemSorting.value)
     }
 
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): MakeListVH {
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ListItemVH {
         val inflater = LayoutInflater.from(parent.context)
         val binding = RecyclerListItemBinding.inflate(inflater, parent, false)
         binding.root.background = parent.background
-        return MakeListVH(binding, listManager, touchHelper, textSize)
+        return ListItemVH(binding, listManager, touchHelper, textSize)
     }
 
     internal fun setList(list: ListItemSortedList) {

--- a/app/src/main/java/com/philkes/notallyx/presentation/view/note/listitem/ListItemDragCallback.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/view/note/listitem/ListItemDragCallback.kt
@@ -8,7 +8,7 @@ import androidx.recyclerview.widget.RecyclerView.ViewHolder
 import com.philkes.notallyx.data.model.ListItem
 
 /** ItemTouchHelper.Callback that allows dragging ListItem with its children. */
-class DragCallback(private val elevation: Float, private val listManager: ListManager) :
+class ListItemDragCallback(private val elevation: Float, private val listManager: ListManager) :
     ItemTouchHelper.Callback() {
 
     private var lastState = ItemTouchHelper.ACTION_STATE_IDLE

--- a/app/src/main/java/com/philkes/notallyx/presentation/view/note/listitem/ListItemListener.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/view/note/listitem/ListItemListener.kt
@@ -1,6 +1,6 @@
 package com.philkes.notallyx.presentation.view.note.listitem
 
-interface ItemListener {
+interface ListItemListener {
 
     fun onClick(position: Int)
 

--- a/app/src/main/java/com/philkes/notallyx/presentation/view/note/listitem/ListItemVH.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/view/note/listitem/ListItemVH.kt
@@ -18,7 +18,7 @@ import com.philkes.notallyx.presentation.view.misc.TextSize
 import com.philkes.notallyx.utils.createListTextWatcherWithHistory
 import com.philkes.notallyx.utils.setOnNextAction
 
-class MakeListVH(
+class ListItemVH(
     val binding: RecyclerListItemBinding,
     val listManager: ListManager,
     touchHelper: ItemTouchHelper,
@@ -38,7 +38,7 @@ class MakeListVH(
             }
 
             editTextWatcher =
-                createListTextWatcherWithHistory(listManager, this@MakeListVH::getAdapterPosition)
+                createListTextWatcherWithHistory(listManager, this@ListItemVH::getAdapterPosition)
             addTextChangedListener(editTextWatcher)
 
             setOnFocusChangeListener { _, hasFocus ->

--- a/app/src/main/java/com/philkes/notallyx/presentation/view/note/listitem/ListManager.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/view/note/listitem/ListManager.kt
@@ -47,7 +47,7 @@ class ListManager(
 
     private var nextItemId: Int = 0
     private lateinit var items: ListItemSortedList
-    internal lateinit var adapter: RecyclerView.Adapter<MakeListVH>
+    internal lateinit var adapter: RecyclerView.Adapter<ListItemVH>
 
     fun add(
         position: Int = items.size(),
@@ -69,7 +69,7 @@ class ListManager(
         val positionAfterAdd = items.findById(item.id)!!.first
         recyclerView.post {
             val viewHolder =
-                recyclerView.findViewHolderForAdapterPosition(positionAfterAdd) as MakeListVH?
+                recyclerView.findViewHolderForAdapterPosition(positionAfterAdd) as ListItemVH?
             if (!item.checked && viewHolder != null) {
                 viewHolder.focusEditText(inputMethodManager = inputMethodManager)
             }
@@ -316,7 +316,7 @@ class ListManager(
     }
 
     fun moveFocusToNext(position: Int) {
-        val viewHolder = recyclerView.findViewHolderForAdapterPosition(position + 1) as MakeListVH?
+        val viewHolder = recyclerView.findViewHolderForAdapterPosition(position + 1) as ListItemVH?
         if (viewHolder != null) {
             if (viewHolder.binding.CheckBox.isChecked) {
                 moveFocusToNext(position + 1)

--- a/app/src/main/java/com/philkes/notallyx/presentation/view/note/listitem/MakeListVH.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/view/note/listitem/MakeListVH.kt
@@ -5,6 +5,7 @@ import android.util.TypedValue
 import android.view.KeyEvent
 import android.view.MotionEvent
 import android.view.inputmethod.InputMethodManager
+import android.widget.CompoundButton.OnCheckedChangeListener
 import android.widget.TextView.INVISIBLE
 import android.widget.TextView.VISIBLE
 import androidx.recyclerview.widget.ItemTouchHelper
@@ -104,13 +105,20 @@ class MakeListVH(
         }
     }
 
+    private var checkBoxListener: OnCheckedChangeListener? = null
+
     private fun updateCheckBox(item: ListItem) {
+        if (checkBoxListener == null) {
+            checkBoxListener = OnCheckedChangeListener { buttonView, isChecked ->
+                buttonView!!.setOnCheckedChangeListener(null)
+                listManager.changeChecked(adapterPosition, isChecked)
+                buttonView.setOnCheckedChangeListener(checkBoxListener)
+            }
+        }
         binding.CheckBox.apply {
             setOnCheckedChangeListener(null)
             isChecked = item.checked
-            setOnCheckedChangeListener { _, isChecked ->
-                listManager.changeChecked(adapterPosition, isChecked)
-            }
+            setOnCheckedChangeListener(checkBoxListener)
         }
     }
 

--- a/app/src/main/java/com/philkes/notallyx/presentation/view/note/preview/PreviewFileAdapter.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/view/note/preview/PreviewFileAdapter.kt
@@ -1,4 +1,4 @@
-package com.philkes.notallyx.presentation.view.note
+package com.philkes.notallyx.presentation.view.note.preview
 
 import android.view.LayoutInflater
 import android.view.ViewGroup

--- a/app/src/main/java/com/philkes/notallyx/presentation/view/note/preview/PreviewFileVH.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/view/note/preview/PreviewFileVH.kt
@@ -1,4 +1,4 @@
-package com.philkes.notallyx.presentation.view.note
+package com.philkes.notallyx.presentation.view.note.preview
 
 import androidx.recyclerview.widget.RecyclerView
 import com.philkes.notallyx.R

--- a/app/src/main/java/com/philkes/notallyx/presentation/view/note/preview/PreviewImageAdapter.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/view/note/preview/PreviewImageAdapter.kt
@@ -1,4 +1,4 @@
-package com.philkes.notallyx.presentation.view.note
+package com.philkes.notallyx.presentation.view.note.preview
 
 import android.view.LayoutInflater
 import android.view.ViewGroup

--- a/app/src/main/java/com/philkes/notallyx/presentation/view/note/preview/PreviewImageVH.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/view/note/preview/PreviewImageVH.kt
@@ -1,4 +1,4 @@
-package com.philkes.notallyx.presentation.view.note
+package com.philkes.notallyx.presentation.view.note.preview
 
 import android.graphics.drawable.Drawable
 import android.view.View

--- a/app/src/test/kotlin/com/philkes/notallyx/recyclerview/listmanager/ListManagerMoveTest.kt
+++ b/app/src/test/kotlin/com/philkes/notallyx/recyclerview/listmanager/ListManagerMoveTest.kt
@@ -257,7 +257,7 @@ class ListManagerMoveTest : ListManagerTestBase() {
     @Test
     fun `endDrag parent without children`() {
         setSorting(ListItemSorting.noAutoSort)
-        dragCallback.simulateDrag(3, 1, "D".itemCount)
+        listItemDragCallback.simulateDrag(3, 1, "D".itemCount)
 
         items.assertOrder("A", "D", "B")
         (changeHistory.lookUp() as ListMoveChange).assert(3, 1, 1, " D")
@@ -271,7 +271,7 @@ class ListManagerMoveTest : ListManagerTestBase() {
         listManager.changeIsChild(5, true, false)
         items.printList("Before")
 
-        dragCallback.simulateDrag(4, 2, "E".itemCount)
+        listItemDragCallback.simulateDrag(4, 2, "E".itemCount)
         items.printList("After move 3 to 2")
 
         items.assertOrder("A", "B", "E", "F", "C", "D")
@@ -289,7 +289,7 @@ class ListManagerMoveTest : ListManagerTestBase() {
         items.printList("Before")
 
         // TODO: parents cant be moved into other parents' children yet
-        dragCallback.simulateDrag(4, 2, "E".itemCount)
+        listItemDragCallback.simulateDrag(4, 2, "E".itemCount)
         items.printList("After move 3 to 2")
 
         items.assertOrder("A", "B", "E", "F", "C", "D")
@@ -305,7 +305,7 @@ class ListManagerMoveTest : ListManagerTestBase() {
         listManager.changeIsChild(2, true, false)
         items.printList("Before")
 
-        dragCallback.simulateDrag(0, items.lastIndex, "A".itemCount)
+        listItemDragCallback.simulateDrag(0, items.lastIndex, "A".itemCount)
         items.printList("After move 0 to ${items.lastIndex}")
         // TODO: test is faulty?
         items.assertOrder("D", "E", "F", "A", "B", "C")
@@ -321,7 +321,7 @@ class ListManagerMoveTest : ListManagerTestBase() {
         listManager.changeIsChild(4, true, false)
         items.printList("Before")
 
-        dragCallback.simulateDrag(3, 0, "D".itemCount)
+        listItemDragCallback.simulateDrag(3, 0, "D".itemCount)
         items.printList("After move 3 to 0")
 
         items.assertOrder("D", "E", "A", "B", "C", "F")
@@ -335,7 +335,7 @@ class ListManagerMoveTest : ListManagerTestBase() {
         setSorting(ListItemSorting.noAutoSort)
         listManager.changeIsChild(3, true, false)
 
-        dragCallback.simulateDrag(3, 1, "D".itemCount)
+        listItemDragCallback.simulateDrag(3, 1, "D".itemCount)
 
         items.assertOrder("A", "D", "B", "C", "E", "F")
         "A".assertChildren("D")
@@ -349,7 +349,7 @@ class ListManagerMoveTest : ListManagerTestBase() {
         listManager.changeIsChild(4, true, false)
         listManager.changeIsChild(5, true, false)
 
-        dragCallback.simulateDrag(5, 3, "F".itemCount)
+        listItemDragCallback.simulateDrag(5, 3, "F".itemCount)
 
         items.assertOrder("A", "B", "C", "F", "D", "E")
         "C".assertChildren("F", "D", "E")
@@ -361,7 +361,7 @@ class ListManagerMoveTest : ListManagerTestBase() {
         setSorting(ListItemSorting.noAutoSort)
         listManager.changeIsChild(3, true, false)
 
-        dragCallback.simulateDrag(3, 0, "D".itemCount)
+        listItemDragCallback.simulateDrag(3, 0, "D".itemCount)
 
         items.assertOrder("D", "A", "B", "C", "E", "F")
         "D".assertIsParent()

--- a/app/src/test/kotlin/com/philkes/notallyx/recyclerview/listmanager/ListManagerTestBase.kt
+++ b/app/src/test/kotlin/com/philkes/notallyx/recyclerview/listmanager/ListManagerTestBase.kt
@@ -7,9 +7,9 @@ import com.philkes.notallyx.Preferences
 import com.philkes.notallyx.data.model.ListItem
 import com.philkes.notallyx.presentation.view.misc.BetterLiveData
 import com.philkes.notallyx.presentation.view.misc.ListItemSorting
-import com.philkes.notallyx.presentation.view.note.listitem.DragCallback
+import com.philkes.notallyx.presentation.view.note.listitem.ListItemDragCallback
+import com.philkes.notallyx.presentation.view.note.listitem.ListItemVH
 import com.philkes.notallyx.presentation.view.note.listitem.ListManager
-import com.philkes.notallyx.presentation.view.note.listitem.MakeListVH
 import com.philkes.notallyx.presentation.view.note.listitem.sorting.ListItemNoSortCallback
 import com.philkes.notallyx.presentation.view.note.listitem.sorting.ListItemSortedByCheckedCallback
 import com.philkes.notallyx.presentation.view.note.listitem.sorting.ListItemSortedList
@@ -33,9 +33,9 @@ open class ListManagerTestBase {
     protected lateinit var adapter: RecyclerView.Adapter<*>
     protected lateinit var inputMethodManager: InputMethodManager
     protected lateinit var changeHistory: ChangeHistory
-    protected lateinit var makeListVH: MakeListVH
+    protected lateinit var listItemVH: ListItemVH
     protected lateinit var preferences: Preferences
-    protected lateinit var dragCallback: DragCallback
+    protected lateinit var listItemDragCallback: ListItemDragCallback
 
     protected lateinit var items: ListItemSortedList
 
@@ -48,12 +48,12 @@ open class ListManagerTestBase {
         adapter = mock(RecyclerView.Adapter::class.java)
         inputMethodManager = mock(InputMethodManager::class.java)
         changeHistory = ChangeHistory() {}
-        makeListVH = mock(MakeListVH::class.java)
+        listItemVH = mock(ListItemVH::class.java)
         preferences = mock(Preferences::class.java)
         listManager = ListManager(recyclerView, changeHistory, preferences, inputMethodManager)
-        listManager.adapter = adapter as RecyclerView.Adapter<MakeListVH>
+        listManager.adapter = adapter as RecyclerView.Adapter<ListItemVH>
         // Prepare view holder
-        `when`(recyclerView.findViewHolderForAdapterPosition(anyInt())).thenReturn(makeListVH)
+        `when`(recyclerView.findViewHolderForAdapterPosition(anyInt())).thenReturn(listItemVH)
     }
 
     protected fun setSorting(sorting: String) {
@@ -75,7 +75,7 @@ open class ListManagerTestBase {
             createListItem("F", id = 5, order = 5),
         )
         listManager.initList(items)
-        dragCallback = DragCallback(1.0f, listManager)
+        listItemDragCallback = ListItemDragCallback(1.0f, listManager)
         `when`(preferences.listItemSorting).thenReturn(BetterLiveData(sorting))
     }
 

--- a/app/src/test/kotlin/com/philkes/notallyx/test/TestUtils.kt
+++ b/app/src/test/kotlin/com/philkes/notallyx/test/TestUtils.kt
@@ -2,7 +2,7 @@ package com.philkes.notallyx.test
 
 import android.util.Log
 import com.philkes.notallyx.data.model.ListItem
-import com.philkes.notallyx.presentation.view.note.listitem.DragCallback
+import com.philkes.notallyx.presentation.view.note.listitem.ListItemDragCallback
 import com.philkes.notallyx.presentation.view.note.listitem.sorting.ListItemSortedList
 import com.philkes.notallyx.presentation.view.note.listitem.sorting.find
 import com.philkes.notallyx.presentation.view.note.listitem.sorting.toReadableString
@@ -39,7 +39,7 @@ fun mockAndroidLog() {
     every { Log.e(any(), any()) } returns 0
 }
 
-fun DragCallback.simulateDrag(positionFrom: Int, positionTo: Int, itemCount: Int) {
+fun ListItemDragCallback.simulateDrag(positionFrom: Int, positionTo: Int, itemCount: Int) {
     this.reset()
     var from = positionFrom
     if (positionFrom < positionTo) {


### PR DESCRIPTION
Might fix #12 

So I think the problem that it sometimes seems like the CheckBox toggling is not working is not related to any backup, move or subtask issue, but rather that when you toggle the CheckBox it triggers an `RecyclerView.Adapater.notifyItemChanged` which in turn sets the value of the CheckBox again. Now if the user toggles the CheckBox, and while the `OnCheckedChangeListener` is still executed the user toggles it again, this change will be immediately overwritten by the  `RecyclerView.Adapater.notifyItemChanged` of the previous toggle. There is always a slight delay between the user toggling the CheckBox and the `OnCheckedChangeListener` completing, not much you can do about that.

With this PR i disabled the `OnCheckedChangeListener` while it is running, meaning if the user toggles "too fast" it will skip that toggle.

You can see the delay quite clearly if you check a parent with some children:

[notally_issues_15_2.webm](https://github.com/user-attachments/assets/dc36d2fe-5f55-4230-9a4e-a43fd353cabb)

Note: I also added small refactorings that I missed in #25 :
* Renamed `MakeListVH`  to `ListItemVH`
* Renamed `MakeListAdapter` to `ListItemAdapter`
* Moved `PreviewFile...` + `PreviewImage...` into `preview` subpackage
