### PR TITLE
Add biometric/pin lock with database encryption

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -84,6 +84,9 @@ dependencies {
     ksp "androidx.room:room-compiler:$roomVersion"
     implementation "androidx.room:room-ktx:$roomVersion"
     implementation "androidx.room:room-runtime:$roomVersion"
+    implementation "net.zetetic:android-database-sqlcipher:4.5.3"
+    implementation "androidx.sqlite:sqlite-ktx:2.4.0"
+    implementation "androidx.security:security-crypto:1.1.0-alpha06"
 
     implementation "androidx.work:work-runtime:2.9.1"
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,6 +13,8 @@
 
     <uses-permission android:name="android.permission.USE_BIOMETRIC" />
 
+    <uses-permission android:name="android.permission.USE_FINGERPRINT" />
+
     <application
         android:name=".NotallyXApplication"
         android:allowBackup="true"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,6 +11,8 @@
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
 
+    <uses-permission android:name="android.permission.USE_BIOMETRIC" />
+
     <application
         android:name=".NotallyXApplication"
         android:allowBackup="true"

--- a/app/src/main/java/com/philkes/notallyx/NotallyXApplication.kt
+++ b/app/src/main/java/com/philkes/notallyx/NotallyXApplication.kt
@@ -16,7 +16,7 @@ class NotallyXApplication : Application() {
     private lateinit var preferences: Preferences
     private var unlockReceiver: UnlockReceiver? = null
 
-    var needUnlock = true
+    var isLocked = true
 
     override fun onCreate() {
         super.onCreate()
@@ -47,6 +47,5 @@ class NotallyXApplication : Application() {
             }
         }
         preferences.biometricLock.observeForever(biometricLockObserver)
-
     }
 }

--- a/app/src/main/java/com/philkes/notallyx/NotallyXApplication.kt
+++ b/app/src/main/java/com/philkes/notallyx/NotallyXApplication.kt
@@ -1,16 +1,27 @@
 package com.philkes.notallyx
 
 import android.app.Application
+import android.content.Intent
+import android.content.IntentFilter
 import androidx.appcompat.app.AppCompatDelegate
+import androidx.lifecycle.Observer
+import com.philkes.notallyx.presentation.view.misc.BiometricLock.enabled
 import com.philkes.notallyx.presentation.view.misc.Theme
 import com.philkes.notallyx.utils.backup.scheduleAutoBackup
+import com.philkes.notallyx.utils.security.UnlockReceiver
 
 class NotallyXApplication : Application() {
+
+    private lateinit var biometricLockObserver: Observer<String>
+    private lateinit var preferences: Preferences
+    private var unlockReceiver: UnlockReceiver? = null
+
+    var needUnlock = true
 
     override fun onCreate() {
         super.onCreate()
 
-        val preferences = Preferences.getInstance(this)
+        preferences = Preferences.getInstance(this)
         preferences.theme.observeForever { theme ->
             when (theme) {
                 Theme.dark ->
@@ -23,6 +34,19 @@ class NotallyXApplication : Application() {
                     )
             }
         }
+
         scheduleAutoBackup(preferences.autoBackupPeriodDays.value.toLong(), this)
+
+        val filter = IntentFilter().apply { addAction(Intent.ACTION_SCREEN_OFF) }
+        biometricLockObserver = Observer {
+            if (it == enabled) {
+                unlockReceiver = UnlockReceiver(this)
+                registerReceiver(unlockReceiver, filter)
+            } else if (unlockReceiver != null) {
+                unregisterReceiver(unlockReceiver)
+            }
+        }
+        preferences.biometricLock.observeForever(biometricLockObserver)
+
     }
 }

--- a/app/src/main/java/com/philkes/notallyx/Preferences.kt
+++ b/app/src/main/java/com/philkes/notallyx/Preferences.kt
@@ -6,6 +6,7 @@ import com.philkes.notallyx.presentation.view.misc.AutoBackup
 import com.philkes.notallyx.presentation.view.misc.AutoBackupMax
 import com.philkes.notallyx.presentation.view.misc.AutoBackupPeriodDays
 import com.philkes.notallyx.presentation.view.misc.BetterLiveData
+import com.philkes.notallyx.presentation.view.misc.BiometricLock
 import com.philkes.notallyx.presentation.view.misc.DateFormat
 import com.philkes.notallyx.presentation.view.misc.ListInfo
 import com.philkes.notallyx.presentation.view.misc.ListItemSorting
@@ -46,6 +47,8 @@ class Preferences private constructor(app: Application) {
     val autoBackupPath = BetterLiveData(getTextPref(AutoBackup))
     var autoBackupPeriodDays = BetterLiveData(getSeekbarPref(AutoBackupPeriodDays))
     var autoBackupMax = getSeekbarPref(AutoBackupMax)
+
+    val biometricLock = BetterLiveData(getListPref(BiometricLock))
 
     private fun getListPref(info: ListInfo) =
         requireNotNull(preferences.getString(info.key, info.defaultValue))
@@ -125,6 +128,7 @@ class Preferences private constructor(app: Application) {
             DateFormat -> dateFormat.postValue(getListPref(info))
             TextSize -> textSize.postValue(getListPref(info))
             ListItemSorting -> listItemSorting.postValue(getListPref(info))
+            BiometricLock -> biometricLock.postValue(getListPref(info))
             else -> return
         }
     }

--- a/app/src/main/java/com/philkes/notallyx/Preferences.kt
+++ b/app/src/main/java/com/philkes/notallyx/Preferences.kt
@@ -1,6 +1,7 @@
 package com.philkes.notallyx
 
 import android.app.Application
+import android.os.Build
 import android.preference.PreferenceManager
 import com.philkes.notallyx.presentation.view.misc.AutoBackup
 import com.philkes.notallyx.presentation.view.misc.AutoBackupMax
@@ -20,6 +21,14 @@ import com.philkes.notallyx.presentation.view.misc.TextInfo
 import com.philkes.notallyx.presentation.view.misc.TextSize
 import com.philkes.notallyx.presentation.view.misc.Theme
 import com.philkes.notallyx.presentation.view.misc.View
+import com.philkes.notallyx.utils.toPreservedByteArray
+import com.philkes.notallyx.utils.toPreservedString
+import java.security.SecureRandom
+import javax.crypto.Cipher
+
+private const val DATABASE_ENCRYPTION_KEY = "database_encryption_key"
+
+private const val ENCRYPTION_IV = "encryption_iv"
 
 /**
  * Custom implementation of androidx.preference library Way faster, simpler and smaller, logic of
@@ -49,6 +58,39 @@ class Preferences private constructor(app: Application) {
     var autoBackupMax = getSeekbarPref(AutoBackupMax)
 
     val biometricLock = BetterLiveData(getListPref(BiometricLock))
+    var iv: ByteArray?
+        get() = preferences.getString(ENCRYPTION_IV, null)?.toPreservedByteArray
+        set(value) {
+            editor.putString(ENCRYPTION_IV, value?.toPreservedString)
+            editor.commit()
+        }
+
+    fun getDatabasePassphrase(): ByteArray {
+        val string = preferences.getString(DATABASE_ENCRYPTION_KEY, "")!!
+        return string.toPreservedByteArray
+    }
+
+    fun generatePassphrase(cipher: Cipher): ByteArray {
+        val random =
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                SecureRandom.getInstanceStrong()
+            } else {
+                SecureRandom()
+            }
+        val result = ByteArray(64)
+
+        random.nextBytes(result)
+
+        // filter out zero byte values, as SQLCipher does not like them
+        while (result.contains(0)) {
+            random.nextBytes(result)
+        }
+
+        val encryptedPassphrase = cipher.doFinal(result)
+        editor.putString(DATABASE_ENCRYPTION_KEY, encryptedPassphrase.toPreservedString)
+        editor.commit()
+        return result
+    }
 
     private fun getListPref(info: ListInfo) =
         requireNotNull(preferences.getString(info.key, info.defaultValue))

--- a/app/src/main/java/com/philkes/notallyx/data/NotallyDatabase.kt
+++ b/app/src/main/java/com/philkes/notallyx/data/NotallyDatabase.kt
@@ -1,6 +1,8 @@
 package com.philkes.notallyx.data
 
 import android.app.Application
+import android.os.Build
+import androidx.lifecycle.Observer
 import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
@@ -8,12 +10,18 @@ import androidx.room.TypeConverters
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SimpleSQLiteQuery
 import androidx.sqlite.db.SupportSQLiteDatabase
+import com.philkes.notallyx.Preferences
 import com.philkes.notallyx.data.dao.BaseNoteDao
 import com.philkes.notallyx.data.dao.CommonDao
 import com.philkes.notallyx.data.dao.LabelDao
 import com.philkes.notallyx.data.model.BaseNote
 import com.philkes.notallyx.data.model.Converters
 import com.philkes.notallyx.data.model.Label
+import com.philkes.notallyx.presentation.view.misc.BetterLiveData
+import com.philkes.notallyx.presentation.view.misc.BiometricLock.enabled
+import com.philkes.notallyx.utils.observeForeverSkipFirst
+import com.philkes.notallyx.utils.security.getInitializedCipherForDecryption
+import net.sqlcipher.database.SupportFactory
 
 @TypeConverters(Converters::class)
 @Database(entities = [BaseNote::class, Label::class], version = 6)
@@ -29,28 +37,56 @@ abstract class NotallyDatabase : RoomDatabase() {
         getBaseNoteDao().query(SimpleSQLiteQuery("pragma wal_checkpoint(FULL)"))
     }
 
+    private var observer: Observer<String>? = null
+
     companion object {
 
         const val DatabaseName = "NotallyDatabase"
 
-        @Volatile private var instance: NotallyDatabase? = null
+        @Volatile private var instance: BetterLiveData<NotallyDatabase>? = null
 
-        fun getDatabase(app: Application): NotallyDatabase {
+        fun getDatabase(app: Application): BetterLiveData<NotallyDatabase> {
             return instance
                 ?: synchronized(this) {
-                    val instance =
-                        Room.databaseBuilder(app, NotallyDatabase::class.java, DatabaseName)
-                            .addMigrations(
-                                Migration2,
-                                Migration3,
-                                Migration4,
-                                Migration5,
-                                Migration6,
-                            )
-                            .build()
-                    this.instance = instance
-                    return instance
+                    val preferences = Preferences.getInstance(app)
+                    this.instance =
+                        BetterLiveData(
+                            createInstance(app, preferences, preferences.biometricLock.value)
+                        )
+                    return this.instance!!
                 }
+        }
+
+        private fun createInstance(
+            app: Application,
+            preferences: Preferences,
+            biometrickLock: String,
+        ): NotallyDatabase {
+            val instanceBuilder =
+                Room.databaseBuilder(app, NotallyDatabase::class.java, DatabaseName)
+                    .addMigrations(Migration2, Migration3, Migration4, Migration5, Migration6)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                if (biometrickLock == enabled) {
+                    val initializationVector = preferences.iv!!
+                    val cipher = getInitializedCipherForDecryption(iv = initializationVector)
+                    val encryptedPassphrase = preferences.getDatabasePassphrase()
+                    val passphrase = cipher.doFinal(encryptedPassphrase)
+                    val factory = SupportFactory(passphrase)
+                    instanceBuilder.openHelperFactory(factory)
+                }
+                val instance = instanceBuilder.build()
+                instance.observer = Observer { newBiometrickLock ->
+                    NotallyDatabase.instance?.value?.observer?.let {
+                        preferences.biometricLock.removeObserver(it)
+                    }
+                    val newInstance = createInstance(app, preferences, newBiometrickLock)
+                    NotallyDatabase.instance?.postValue(newInstance)
+                    preferences.biometricLock.observeForeverSkipFirst(newInstance.observer!!)
+                }
+                preferences.biometricLock.observeForeverSkipFirst(instance.observer!!)
+                return instance
+            }
+            return instanceBuilder.build()
         }
 
         object Migration2 : Migration(1, 2) {

--- a/app/src/main/java/com/philkes/notallyx/data/model/Content.kt
+++ b/app/src/main/java/com/philkes/notallyx/data/model/Content.kt
@@ -1,6 +1,7 @@
 package com.philkes.notallyx.data.model
 
 import androidx.lifecycle.LiveData
+import androidx.lifecycle.Observer
 
 /**
  * The instance of LiveData returned by Room only listens for changes while the fragment observing
@@ -17,10 +18,20 @@ import androidx.lifecycle.LiveData
  * To stop this, this class acts as a wrapper over the LiveData returned by Room and continuously
  * observes it.
  */
-class Content(liveData: LiveData<List<BaseNote>>, transform: (List<BaseNote>) -> List<Item>) :
-    LiveData<List<Item>>() {
+class Content(
+    private var liveData: LiveData<List<BaseNote>>,
+    private val transform: (List<BaseNote>) -> List<Item>,
+) : LiveData<List<Item>>() {
+    private var observer: Observer<List<BaseNote>>? = null
 
     init {
-        liveData.observeForever { list -> value = transform(list) }
+        setObserver(liveData)
+    }
+
+    fun setObserver(liveData: LiveData<List<BaseNote>>) {
+        observer?.let { this.liveData.removeObserver(it) }
+        this.liveData = liveData
+        observer = Observer { list -> value = transform(list) }
+        this.liveData.observeForever(observer!!)
     }
 }

--- a/app/src/main/java/com/philkes/notallyx/data/model/SearchResult.kt
+++ b/app/src/main/java/com/philkes/notallyx/data/model/SearchResult.kt
@@ -9,7 +9,7 @@ import kotlinx.coroutines.launch
 
 class SearchResult(
     private val scope: CoroutineScope,
-    private val baseNoteDao: BaseNoteDao,
+    var baseNoteDao: BaseNoteDao,
     transform: (List<BaseNote>) -> List<Item>,
 ) : LiveData<List<Item>>() {
 

--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/ConfigureWidgetActivity.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/ConfigureWidgetActivity.kt
@@ -73,13 +73,15 @@ class ConfigureWidgetActivity : LockedActivity<ActivityConfigureWidgetBinding>()
         val pinned = Header(getString(R.string.pinned))
         val others = Header(getString(R.string.others))
 
-        lifecycleScope.launch {
-            val notes =
-                withContext(Dispatchers.IO) {
-                    val raw = database.getBaseNoteDao().getAllNotes()
-                    BaseNoteModel.transform(raw, pinned, others)
-                }
-            adapter.submitList(notes)
+        database.observe(this) {
+            lifecycleScope.launch {
+                val notes =
+                    withContext(Dispatchers.IO) {
+                        val raw = it.getBaseNoteDao().getAllNotes()
+                        BaseNoteModel.transform(raw, pinned, others)
+                    }
+                adapter.submitList(notes)
+            }
         }
     }
 

--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/ConfigureWidgetActivity.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/ConfigureWidgetActivity.kt
@@ -3,7 +3,6 @@ package com.philkes.notallyx.presentation.activity
 import android.appwidget.AppWidgetManager
 import android.content.Intent
 import android.os.Bundle
-import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -25,7 +24,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
-class ConfigureWidgetActivity : AppCompatActivity(), ListItemListener {
+class ConfigureWidgetActivity : LockedActivity<ActivityConfigureWidgetBinding>(), ListItemListener {
 
     private lateinit var adapter: BaseNoteAdapter
     private val id by lazy {
@@ -37,7 +36,7 @@ class ConfigureWidgetActivity : AppCompatActivity(), ListItemListener {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val binding = ActivityConfigureWidgetBinding.inflate(layoutInflater)
+        binding = ActivityConfigureWidgetBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
         val result = Intent()

--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/LockedActivity.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/LockedActivity.kt
@@ -1,0 +1,92 @@
+package com.philkes.notallyx.presentation.activity
+
+import android.app.Activity
+import android.app.KeyguardManager
+import android.content.Intent
+import android.os.Build
+import android.os.Bundle
+import android.view.View.INVISIBLE
+import android.view.View.VISIBLE
+import androidx.appcompat.app.AppCompatActivity
+import androidx.viewbinding.ViewBinding
+import com.philkes.notallyx.NotallyXApplication
+import com.philkes.notallyx.Preferences
+import com.philkes.notallyx.R
+import com.philkes.notallyx.presentation.view.misc.BiometricLock.enabled
+import com.philkes.notallyx.utils.security.showBiometricOrPinPrompt
+
+abstract class LockedActivity<T : ViewBinding> : AppCompatActivity() {
+
+    private lateinit var notallyXApplication: NotallyXApplication
+
+    protected lateinit var binding: T
+    protected lateinit var preferences: Preferences
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        notallyXApplication = (application as NotallyXApplication)
+        preferences = Preferences.getInstance(application)
+    }
+
+    override fun onResume() {
+        if (preferences.biometricLock.value == enabled) {
+            if (hasToAuthenticateWithBiometric()) {
+                hide()
+                showLockScreen()
+            } else {
+                show()
+            }
+        }
+        super.onResume()
+    }
+
+    override fun onPause() {
+        super.onPause()
+        if (preferences.biometricLock.value == enabled) {
+            hide()
+        }
+    }
+
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        super.onActivityResult(requestCode, resultCode, data)
+        if (requestCode == REQUEST_BIOMETRIC_AUTHENTICATION && resultCode == Activity.RESULT_OK) {
+            notallyXApplication.needUnlock = false
+            show()
+        }
+    }
+
+    open fun showLockScreen() {
+        showBiometricOrPinPrompt(
+            REQUEST_BIOMETRIC_AUTHENTICATION,
+            R.string.unlock,
+            {
+                notallyXApplication.needUnlock = false
+                show()
+            },
+        ) {
+            finish()
+        }
+    }
+
+    protected fun show() {
+        binding.root.visibility = VISIBLE
+    }
+
+    protected fun hide() {
+        binding.root.visibility = INVISIBLE
+    }
+
+    private fun hasToAuthenticateWithBiometric(): Boolean {
+        val keyguardManager: KeyguardManager =
+            this.getSystemService(KEYGUARD_SERVICE) as KeyguardManager
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP_MR1) {
+            (keyguardManager.isDeviceLocked || notallyXApplication.needUnlock)
+        } else {
+            false
+        }
+    }
+
+    companion object {
+        private const val REQUEST_BIOMETRIC_AUTHENTICATION = 11
+    }
+}

--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/LockedActivity.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/LockedActivity.kt
@@ -50,17 +50,19 @@ abstract class LockedActivity<T : ViewBinding> : AppCompatActivity() {
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         super.onActivityResult(requestCode, resultCode, data)
         if (requestCode == REQUEST_BIOMETRIC_AUTHENTICATION && resultCode == Activity.RESULT_OK) {
-            notallyXApplication.needUnlock = false
+            notallyXApplication.isLocked = false
             show()
         }
     }
 
     open fun showLockScreen() {
         showBiometricOrPinPrompt(
+            true,
+            preferences.iv!!,
             REQUEST_BIOMETRIC_AUTHENTICATION,
             R.string.unlock,
-            {
-                notallyXApplication.needUnlock = false
+            onSuccess = {
+                notallyXApplication.isLocked = false
                 show()
             },
         ) {
@@ -80,7 +82,7 @@ abstract class LockedActivity<T : ViewBinding> : AppCompatActivity() {
         val keyguardManager: KeyguardManager =
             this.getSystemService(KEYGUARD_SERVICE) as KeyguardManager
         return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP_MR1) {
-            (keyguardManager.isDeviceLocked || notallyXApplication.needUnlock)
+            (keyguardManager.isDeviceLocked || notallyXApplication.isLocked)
         } else {
             false
         }

--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/main/MainActivity.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/main/MainActivity.kt
@@ -46,7 +46,6 @@ import com.philkes.notallyx.utils.Operations
 import com.philkes.notallyx.utils.add
 import com.philkes.notallyx.utils.applySpans
 import com.philkes.notallyx.utils.movedToResId
-import com.philkes.notallyx.utils.checkForBiometrics
 import java.io.File
 import kotlinx.coroutines.launch
 

--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/main/fragment/ArchivedFragment.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/main/fragment/ArchivedFragment.kt
@@ -6,5 +6,5 @@ class ArchivedFragment : NotallyFragment() {
 
     override fun getBackground() = R.drawable.archive
 
-    override fun getObservable() = model.archivedNotes
+    override fun getObservable() = model.archivedNotes!!
 }

--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/main/fragment/DeletedFragment.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/main/fragment/DeletedFragment.kt
@@ -22,5 +22,5 @@ class DeletedFragment : NotallyFragment() {
 
     override fun getBackground() = R.drawable.delete
 
-    override fun getObservable() = model.deletedNotes
+    override fun getObservable() = model.deletedNotes!!
 }

--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/main/fragment/NotesFragment.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/main/fragment/NotesFragment.kt
@@ -14,7 +14,7 @@ class NotesFragment : NotallyFragment() {
         }
     }
 
-    override fun getObservable() = model.baseNotes
+    override fun getObservable() = model.baseNotes!!
 
     override fun getBackground() = R.drawable.notebook
 }

--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/main/fragment/SearchFragment.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/main/fragment/SearchFragment.kt
@@ -36,5 +36,5 @@ class SearchFragment : NotallyFragment() {
 
     override fun getBackground() = R.drawable.search
 
-    override fun getObservable() = model.searchResults
+    override fun getObservable() = model.searchResults!!
 }

--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/note/EditActivity.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/note/EditActivity.kt
@@ -18,7 +18,6 @@ import android.view.ViewGroup.LayoutParams
 import android.widget.Toast
 import androidx.activity.viewModels
 import androidx.annotation.RequiresApi
-import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.FileProvider
 import androidx.core.view.isVisible
 import androidx.core.widget.doAfterTextChanged
@@ -27,7 +26,6 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.PagerSnapHelper
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
-import com.philkes.notallyx.Preferences
 import com.philkes.notallyx.R
 import com.philkes.notallyx.data.model.Audio
 import com.philkes.notallyx.data.model.FileAttachment
@@ -35,6 +33,7 @@ import com.philkes.notallyx.data.model.Folder
 import com.philkes.notallyx.data.model.Type
 import com.philkes.notallyx.databinding.ActivityEditBinding
 import com.philkes.notallyx.databinding.DialogProgressBinding
+import com.philkes.notallyx.presentation.activity.LockedActivity
 import com.philkes.notallyx.presentation.view.Constants
 import com.philkes.notallyx.presentation.view.misc.TextSize
 import com.philkes.notallyx.presentation.view.note.ErrorAdapter
@@ -52,12 +51,8 @@ import java.io.File
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
-abstract class EditActivity(private val type: Type) : AppCompatActivity() {
-
-    internal lateinit var binding: ActivityEditBinding
-
+abstract class EditActivity(private val type: Type) : LockedActivity<ActivityEditBinding>() {
     internal val model: NotallyModel by viewModels()
-    internal lateinit var preferences: Preferences
     internal lateinit var changeHistory: ChangeHistory
 
     override fun finish() {
@@ -83,7 +78,6 @@ abstract class EditActivity(private val type: Type) : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        preferences = Preferences.getInstance(application)
         model.type = type
         initialiseBinding()
         setContentView(binding.root)

--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/note/PlayAudioActivity.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/note/PlayAudioActivity.kt
@@ -7,13 +7,13 @@ import android.net.Uri
 import android.os.Bundle
 import android.os.IBinder
 import android.widget.Toast
-import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.FileProvider
 import androidx.lifecycle.lifecycleScope
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.philkes.notallyx.R
 import com.philkes.notallyx.data.model.Audio
 import com.philkes.notallyx.databinding.ActivityPlayAudioBinding
+import com.philkes.notallyx.presentation.activity.LockedActivity
 import com.philkes.notallyx.utils.IO
 import com.philkes.notallyx.utils.add
 import com.philkes.notallyx.utils.audio.AudioPlayService
@@ -26,13 +26,12 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
-class PlayAudioActivity : AppCompatActivity() {
+class PlayAudioActivity : LockedActivity<ActivityPlayAudioBinding>() {
 
     private var service: AudioPlayService? = null
     private lateinit var connection: ServiceConnection
 
     private lateinit var audio: Audio
-    private lateinit var binding: ActivityPlayAudioBinding
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/note/RecordAudioActivity.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/note/RecordAudioActivity.kt
@@ -6,24 +6,24 @@ import android.content.ServiceConnection
 import android.os.Bundle
 import android.os.IBinder
 import androidx.annotation.RequiresApi
-import androidx.appcompat.app.AppCompatActivity
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.philkes.notallyx.R
 import com.philkes.notallyx.databinding.ActivityRecordAudioBinding
+import com.philkes.notallyx.presentation.activity.LockedActivity
 import com.philkes.notallyx.utils.IO
 import com.philkes.notallyx.utils.audio.AudioRecordService
 import com.philkes.notallyx.utils.audio.LocalBinder
 import com.philkes.notallyx.utils.audio.Status
 
 @RequiresApi(24)
-class RecordAudioActivity : AppCompatActivity() {
+class RecordAudioActivity : LockedActivity<ActivityRecordAudioBinding>() {
 
     private var service: AudioRecordService? = null
     private lateinit var connection: ServiceConnection
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val binding = ActivityRecordAudioBinding.inflate(layoutInflater)
+        binding = ActivityRecordAudioBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
         val intent = Intent(this, AudioRecordService::class.java)

--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/note/SelectLabelsActivity.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/note/SelectLabelsActivity.kt
@@ -5,7 +5,6 @@ import android.os.Bundle
 import android.view.View
 import android.widget.Toast
 import androidx.activity.viewModels
-import androidx.appcompat.app.AppCompatActivity
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
@@ -13,14 +12,14 @@ import com.philkes.notallyx.R
 import com.philkes.notallyx.data.model.Label
 import com.philkes.notallyx.databinding.ActivityLabelBinding
 import com.philkes.notallyx.databinding.DialogInputBinding
+import com.philkes.notallyx.presentation.activity.LockedActivity
 import com.philkes.notallyx.presentation.view.main.SelectableLabelAdapter
 import com.philkes.notallyx.presentation.viewmodel.LabelModel
 import com.philkes.notallyx.utils.add
 
-class SelectLabelsActivity : AppCompatActivity() {
+class SelectLabelsActivity : LockedActivity<ActivityLabelBinding>() {
 
     private val model: LabelModel by viewModels()
-    private lateinit var binding: ActivityLabelBinding
 
     private lateinit var selectedLabels: ArrayList<String>
 

--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/note/ViewImageActivity.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/note/ViewImageActivity.kt
@@ -60,19 +60,21 @@ class ViewImageActivity : LockedActivity<ActivityViewImageBinding>() {
         val initial = intent.getIntExtra(POSITION, 0)
         binding.RecyclerView.scrollToPosition(initial)
 
-        lifecycleScope.launch {
-            val database = NotallyDatabase.getDatabase(application)
-            val id = intent.getLongExtra(Constants.SelectedBaseNote, 0)
+        val database = NotallyDatabase.getDatabase(application)
+        val id = intent.getLongExtra(Constants.SelectedBaseNote, 0)
 
-            val json = withContext(Dispatchers.IO) { database.getBaseNoteDao().getImages(id) }
-            val original = Converters.jsonToFiles(json)
-            val images = ArrayList<FileAttachment>(original.size)
-            original.filterNotTo(images) { image -> deletedImages.contains(image) }
+        database.observe(this@ViewImageActivity) {
+            lifecycleScope.launch {
+                val json = withContext(Dispatchers.IO) { it.getBaseNoteDao().getImages(id) }
+                val original = Converters.jsonToFiles(json)
+                val images = ArrayList<FileAttachment>(original.size)
+                original.filterNotTo(images) { image -> deletedImages.contains(image) }
 
-            val mediaRoot = IO.getExternalImagesDirectory(application)
-            val adapter = ImageAdapter(mediaRoot, images)
-            binding.RecyclerView.adapter = adapter
-            setupToolbar(binding, adapter)
+                val mediaRoot = IO.getExternalImagesDirectory(application)
+                val adapter = ImageAdapter(mediaRoot, images)
+                binding.RecyclerView.adapter = adapter
+                setupToolbar(binding, adapter)
+            }
         }
     }
 

--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/note/ViewImageActivity.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/note/ViewImageActivity.kt
@@ -5,7 +5,6 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
 import android.widget.Toast
-import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.FileProvider
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -17,6 +16,7 @@ import com.philkes.notallyx.data.NotallyDatabase
 import com.philkes.notallyx.data.model.Converters
 import com.philkes.notallyx.data.model.FileAttachment
 import com.philkes.notallyx.databinding.ActivityViewImageBinding
+import com.philkes.notallyx.presentation.activity.LockedActivity
 import com.philkes.notallyx.presentation.view.Constants
 import com.philkes.notallyx.presentation.view.note.image.ImageAdapter
 import com.philkes.notallyx.utils.IO
@@ -28,14 +28,14 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
-class ViewImageActivity : AppCompatActivity() {
+class ViewImageActivity : LockedActivity<ActivityViewImageBinding>() {
 
     private var currentImage: FileAttachment? = null
     private lateinit var deletedImages: ArrayList<FileAttachment>
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val binding = ActivityViewImageBinding.inflate(layoutInflater)
+        binding = ActivityViewImageBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
         val savedList = savedInstanceState?.getParcelableArrayList<FileAttachment>(DELETED_IMAGES)

--- a/app/src/main/java/com/philkes/notallyx/presentation/view/misc/ListInfo.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/view/misc/ListInfo.kt
@@ -179,3 +179,19 @@ enum class SortDirection(val textResId: Int, val iconResId: Int) {
     ASC(R.string.ascending, R.drawable.arrow_upward),
     DESC(R.string.descending, R.drawable.arrow_downward),
 }
+
+object BiometricLock : ListInfo {
+    const val enabled = "enabled"
+    const val disabled = "disabled"
+
+    override val title = R.string.biometric_lock
+    override val key = "biometricLock"
+    override val defaultValue = disabled
+
+    override fun getEntryValues() = arrayOf(enabled, disabled)
+
+    override fun getEntries(context: Context): Array<String> {
+        val ids = arrayOf(R.string.enabled, R.string.disabled)
+        return convertToValues(ids, context)
+    }
+}

--- a/app/src/main/java/com/philkes/notallyx/presentation/viewmodel/LabelModel.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/viewmodel/LabelModel.kt
@@ -2,14 +2,22 @@ package com.philkes.notallyx.presentation.viewmodel
 
 import android.app.Application
 import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.LiveData
 import com.philkes.notallyx.data.NotallyDatabase
+import com.philkes.notallyx.data.dao.LabelDao
 import com.philkes.notallyx.data.model.Label
 
 class LabelModel(app: Application) : AndroidViewModel(app) {
 
-    private val database = NotallyDatabase.getDatabase(app)
-    private val labelDao = database.getLabelDao()
-    val labels = labelDao.getAll()
+    private lateinit var labelDao: LabelDao
+    lateinit var labels: LiveData<List<String>>
+
+    init {
+        NotallyDatabase.getDatabase(app).observeForever {
+            labelDao = it.getLabelDao()
+            labels = labelDao.getAll()
+        }
+    }
 
     fun insertLabel(label: Label, onComplete: (success: Boolean) -> Unit) =
         executeAsyncWithCallback({ labelDao.insert(label) }, onComplete)

--- a/app/src/main/java/com/philkes/notallyx/presentation/viewmodel/NotallyModel.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/viewmodel/NotallyModel.kt
@@ -27,6 +27,7 @@ import com.philkes.notallyx.Preferences
 import com.philkes.notallyx.R
 import com.philkes.notallyx.data.AttachmentDeleteService
 import com.philkes.notallyx.data.NotallyDatabase
+import com.philkes.notallyx.data.dao.BaseNoteDao
 import com.philkes.notallyx.data.model.Audio
 import com.philkes.notallyx.data.model.BaseNote
 import com.philkes.notallyx.data.model.Color
@@ -54,7 +55,7 @@ import kotlinx.coroutines.withContext
 class NotallyModel(private val app: Application) : AndroidViewModel(app) {
 
     private val database = NotallyDatabase.getDatabase(app)
-    private val baseNoteDao = database.getBaseNoteDao()
+    private lateinit var baseNoteDao: BaseNoteDao
 
     val textSize = Preferences.getInstance(app).textSize.value
 
@@ -86,6 +87,10 @@ class NotallyModel(private val app: Application) : AndroidViewModel(app) {
     var imageRoot = IO.getExternalImagesDirectory(app)
     var audioRoot = IO.getExternalAudioDirectory(app)
     var filesRoot = IO.getExternalFilesDirectory(app)
+
+    init {
+        database.observeForever { baseNoteDao = it.getBaseNoteDao() }
+    }
 
     fun addAudio() {
         viewModelScope.launch {

--- a/app/src/main/java/com/philkes/notallyx/presentation/widget/WidgetFactory.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/widget/WidgetFactory.kt
@@ -21,8 +21,12 @@ class WidgetFactory(private val app: Application, private val id: Long, private 
     RemoteViewsService.RemoteViewsFactory {
 
     private var baseNote: BaseNote? = null
-    private val database = NotallyDatabase.getDatabase(app)
+    private lateinit var database: NotallyDatabase
     private val preferences = Preferences.getInstance(app)
+
+    init {
+        NotallyDatabase.getDatabase(app).observeForever { database = it }
+    }
 
     override fun onCreate() {}
 

--- a/app/src/main/java/com/philkes/notallyx/presentation/widget/WidgetProvider.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/widget/WidgetProvider.kt
@@ -50,7 +50,7 @@ class WidgetProvider : AppWidgetProvider() {
         val noteId = intent.getLongExtra(Constants.SelectedBaseNote, 0)
         val position = intent.getIntExtra(EXTRA_POSITION, 0)
         val checked = intent.getBooleanExtra(RemoteViews.EXTRA_CHECKED, false)
-        val database = NotallyDatabase.getDatabase(context.applicationContext as Application)
+        val database = NotallyDatabase.getDatabase(context.applicationContext as Application).value
         val pendingResult = goAsync()
         GlobalScope.launch {
             withContext(Dispatchers.IO) {

--- a/app/src/main/java/com/philkes/notallyx/utils/Extensions.kt
+++ b/app/src/main/java/com/philkes/notallyx/utils/Extensions.kt
@@ -30,6 +30,8 @@ import android.widget.RadioGroup
 import android.widget.RemoteViews
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity.KEYGUARD_SERVICE
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.Observer
 import com.philkes.notallyx.R
 import com.philkes.notallyx.data.model.FileAttachment
 import com.philkes.notallyx.data.model.Folder
@@ -302,6 +304,27 @@ fun Context.canAuthenticateWithBiometrics(): Int {
         }
     }
     return BiometricManager.BIOMETRIC_ERROR_NO_HARDWARE
+}
+
+val String.toPreservedByteArray: ByteArray
+    get() {
+        return this.toByteArray(Charsets.ISO_8859_1)
+    }
+
+val ByteArray.toPreservedString: String
+    get() {
+        return String(this, Charsets.ISO_8859_1)
+    }
+
+fun <T> LiveData<T>.observeForeverSkipFirst(observer: Observer<T>) {
+    var isFirstEvent = true
+    this.observeForever { value ->
+        if (isFirstEvent) {
+            isFirstEvent = false
+        } else {
+            observer.onChanged(value)
+        }
+    }
 }
 
 private fun formatTimestamp(timestamp: Long, dateFormat: String): String {

--- a/app/src/main/java/com/philkes/notallyx/utils/Extensions.kt
+++ b/app/src/main/java/com/philkes/notallyx/utils/Extensions.kt
@@ -267,7 +267,6 @@ val FileAttachment.isImage: Boolean
     get() {
         return mimeType.startsWith("image/")
     }
-
 fun Folder.movedToResId(): Int {
     return when (this) {
         Folder.DELETED -> R.plurals.deleted_selected_notes
@@ -279,40 +278,30 @@ fun Folder.movedToResId(): Int {
 fun RadioGroup.checkedTag(): Any {
     return this.findViewById<RadioButton?>(this.checkedRadioButtonId).tag
 }
-
-fun Context.checkForBiometrics(): Boolean {
+fun Context.canAuthenticateWithBiometrics(): Int {
     var canAuthenticate = true
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-        if (Build.VERSION.SDK_INT < 29) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
             val keyguardManager: KeyguardManager =
                 this.getSystemService(KEYGUARD_SERVICE) as KeyguardManager
             val packageManager: PackageManager = this.packageManager
             if (!packageManager.hasSystemFeature(PackageManager.FEATURE_FINGERPRINT)) {
-                canAuthenticate = false
+                return BiometricManager.BIOMETRIC_ERROR_NO_HARDWARE
             }
             if (!keyguardManager.isKeyguardSecure) {
-                canAuthenticate = false
+                return BiometricManager.BIOMETRIC_ERROR_NONE_ENROLLED
             }
-        } else if (Build.VERSION.SDK_INT < 30) {
+        } else if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
             val biometricManager: BiometricManager =
                 this.getSystemService(BiometricManager::class.java)
-            if (biometricManager.canAuthenticate() != BiometricManager.BIOMETRIC_SUCCESS) {
-                canAuthenticate = false
-            }
+            return biometricManager.canAuthenticate()
         } else {
             val biometricManager: BiometricManager =
                 this.getSystemService(BiometricManager::class.java)
-            if (
-                biometricManager.canAuthenticate(BIOMETRIC_STRONG or DEVICE_CREDENTIAL) !=
-                    BiometricManager.BIOMETRIC_SUCCESS
-            ) {
-                canAuthenticate = false
-            }
+            return biometricManager.canAuthenticate(BIOMETRIC_STRONG or DEVICE_CREDENTIAL)
         }
-    } else {
-        canAuthenticate = false
     }
-    return canAuthenticate
+    return BiometricManager.BIOMETRIC_ERROR_NO_HARDWARE
 }
 
 private fun formatTimestamp(timestamp: Long, dateFormat: String): String {

--- a/app/src/main/java/com/philkes/notallyx/utils/backup/Export.kt
+++ b/app/src/main/java/com/philkes/notallyx/utils/backup/Export.kt
@@ -9,12 +9,15 @@ import java.util.zip.ZipOutputStream
 
 object Export {
 
-    fun backupDatabase(app: Application, zipStream: ZipOutputStream) {
+    fun backupDatabase(
+        app: Application,
+        zipStream: ZipOutputStream,
+        databaseFile: File = app.getDatabasePath(NotallyDatabase.DatabaseName),
+    ) {
         val entry = ZipEntry(NotallyDatabase.DatabaseName)
         zipStream.putNextEntry(entry)
 
-        val file = app.getDatabasePath(NotallyDatabase.DatabaseName)
-        val inputStream = FileInputStream(file)
+        val inputStream = FileInputStream(databaseFile)
         inputStream.copyTo(zipStream)
         inputStream.close()
 

--- a/app/src/main/java/com/philkes/notallyx/utils/backup/XMLUtils.kt
+++ b/app/src/main/java/com/philkes/notallyx/utils/backup/XMLUtils.kt
@@ -123,7 +123,6 @@ object XMLUtils {
         var isChild = false
         var order: Int? = null
 
-        // TODO: migration required?
         while (parser.next() != XmlPullParser.END_DOCUMENT) {
             if (parser.eventType == XmlPullParser.START_TAG) {
                 when (parser.name) {

--- a/app/src/main/java/com/philkes/notallyx/utils/security/EncryptionUtils.kt
+++ b/app/src/main/java/com/philkes/notallyx/utils/security/EncryptionUtils.kt
@@ -1,0 +1,104 @@
+package com.philkes.notallyx.utils.security
+
+import android.content.Context
+import android.os.Build
+import android.security.keystore.KeyGenParameterSpec
+import android.security.keystore.KeyProperties
+import androidx.annotation.RequiresApi
+import com.philkes.notallyx.data.NotallyDatabase.Companion.DatabaseName
+import java.io.File
+import java.security.KeyStore
+import javax.crypto.Cipher
+import javax.crypto.KeyGenerator
+import javax.crypto.SecretKey
+import javax.crypto.spec.IvParameterSpec
+
+private const val ENCRYPTION_KEY_NAME = "notallyx_database_encryption_key"
+
+private const val ANDROID_KEYSTORE = "AndroidKeyStore"
+
+fun encryptDatabase(context: Context, passphrase: ByteArray) {
+    val state = SQLCipherUtils.getDatabaseState(context, DatabaseName)
+    if (state == SQLCipherUtils.State.UNENCRYPTED) {
+        SQLCipherUtils.encrypt(context, DatabaseName, passphrase)
+    }
+}
+
+fun decryptDatabase(context: Context, passphrase: ByteArray) {
+    val state = SQLCipherUtils.getDatabaseState(context, DatabaseName)
+    if (state == SQLCipherUtils.State.ENCRYPTED) {
+        SQLCipherUtils.decrypt(context, DatabaseName, passphrase)
+    }
+}
+
+fun decryptDatabase(context: Context, passphrase: ByteArray, decryptedFile: File) {
+    val state = SQLCipherUtils.getDatabaseState(context, DatabaseName)
+    if (state == SQLCipherUtils.State.ENCRYPTED) {
+        SQLCipherUtils.decrypt(context, DatabaseName, decryptedFile, passphrase)
+    }
+}
+
+@RequiresApi(Build.VERSION_CODES.M)
+private fun getOrCreateSecretKey(keyName: String = ENCRYPTION_KEY_NAME): SecretKey {
+    // If Secretkey was previously created for that keyName, then grab and return it.
+    val keyStore = KeyStore.getInstance(ANDROID_KEYSTORE)
+    keyStore.load(null) // Keystore must be loaded before it can be accessed
+    keyStore.getKey(keyName, null)?.let {
+        return it as SecretKey
+    }
+
+    // if you reach here, then a new SecretKey must be generated for that keyName
+    val keyGenParams =
+        KeyGenParameterSpec.Builder(
+                keyName,
+                KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT,
+            )
+            .setBlockModes(KeyProperties.BLOCK_MODE_CBC)
+            .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_PKCS7)
+            //        .setUserAuthenticationRequired(true)
+            // Invalidate the keys if the user has registered a new biometric
+            // credential, such as a new fingerprint. Can call this method only
+            // on Android 7.0 (API level 24) or higher. The variable
+            // "invalidatedByBiometricEnrollment" is true by default.
+            //            .setInvalidatedByBiometricEnrollment(true) // TODO:
+            // The other important property is setUserAuthenticationValidityDurationSeconds().
+            // If it is set to -1 then the key can only be unlocked using Fingerprint or Biometrics.
+            // If it is set to any other value, the key can be unlocked using a device screenlock
+            // too.
+            .setUserAuthenticationValidityDurationSeconds(-1)
+            .build()
+
+    val keyGenerator = KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, ANDROID_KEYSTORE)
+    keyGenerator.init(keyGenParams)
+    return keyGenerator.generateKey()
+}
+
+@RequiresApi(Build.VERSION_CODES.M)
+fun getInitializedCipherForEncryption(keyName: String = ENCRYPTION_KEY_NAME): Cipher {
+    val cipher = getCipher()
+    val secretKey = getOrCreateSecretKey(keyName)
+    cipher.init(Cipher.ENCRYPT_MODE, secretKey)
+    return cipher
+}
+
+@RequiresApi(Build.VERSION_CODES.M)
+fun getInitializedCipherForDecryption(
+    keyName: String = ENCRYPTION_KEY_NAME,
+    iv: ByteArray,
+): Cipher {
+    val cipher = getCipher()
+    val secretKey = getOrCreateSecretKey(keyName)
+    cipher.init(Cipher.DECRYPT_MODE, secretKey, IvParameterSpec(iv))
+    return cipher
+}
+
+@RequiresApi(Build.VERSION_CODES.M)
+private fun getCipher(): Cipher {
+    return Cipher.getInstance(
+        KeyProperties.KEY_ALGORITHM_AES +
+            "/" +
+            KeyProperties.BLOCK_MODE_CBC +
+            "/" +
+            KeyProperties.ENCRYPTION_PADDING_PKCS7
+    )
+}

--- a/app/src/main/java/com/philkes/notallyx/utils/security/LockUtils.kt
+++ b/app/src/main/java/com/philkes/notallyx/utils/security/LockUtils.kt
@@ -1,0 +1,214 @@
+package com.philkes.notallyx.utils.security
+
+import android.app.Activity
+import android.app.KeyguardManager
+import android.content.Context
+import android.content.Intent
+import android.hardware.biometrics.BiometricManager
+import android.hardware.biometrics.BiometricPrompt
+import android.hardware.fingerprint.FingerprintManager
+import android.os.Build
+import android.os.CancellationSignal
+import androidx.fragment.app.Fragment
+import com.philkes.notallyx.R
+
+fun Activity.showBiometricOrPinPrompt(
+    requestCode: Int,
+    title: Int,
+    onSuccess: () -> Unit,
+    onFailure: () -> Unit,
+) {
+    showBiometricOrPinPrompt(
+        this,
+        requestCode,
+        title,
+        onSuccess,
+        ::startActivityForResult,
+        onFailure,
+    )
+}
+
+fun Fragment.showBiometricOrPinPrompt(
+    requestCode: Int,
+    title: Int,
+    onSuccess: () -> Unit,
+    onFailure: () -> Unit,
+) {
+    showBiometricOrPinPrompt(
+        requireContext(),
+        requestCode,
+        title,
+        onSuccess,
+        ::startActivityForResult,
+        onFailure,
+    )
+}
+
+private fun showBiometricOrPinPrompt(
+    context: Context,
+    requestCode: Int,
+    title: Int,
+    onSuccess: () -> Unit,
+    startActivityForResult: (intent: Intent, requestCode: Int) -> Unit,
+    onFailure: () -> Unit,
+) {
+    when {
+        Build.VERSION.SDK_INT >= Build.VERSION_CODES.R -> {
+            // API 30 and above: Use BiometricPrompt with setAllowedAuthenticators
+            val prompt =
+                BiometricPrompt.Builder(context)
+                    .setTitle(context.getString(title))
+                    .setAllowedAuthenticators(
+                        BiometricManager.Authenticators.BIOMETRIC_STRONG or
+                            BiometricManager.Authenticators.DEVICE_CREDENTIAL
+                    )
+                    .build()
+            prompt.authenticate(
+                getCancellationSignal(context),
+                context.mainExecutor,
+                object : BiometricPrompt.AuthenticationCallback() {
+                    override fun onAuthenticationSucceeded(
+                        result: BiometricPrompt.AuthenticationResult?
+                    ) {
+                        super.onAuthenticationSucceeded(result)
+                        onSuccess.invoke()
+                    }
+
+                    override fun onAuthenticationFailed() {
+                        super.onAuthenticationFailed()
+                        onFailure.invoke()
+                    }
+                },
+            )
+        }
+
+        Build.VERSION.SDK_INT >= Build.VERSION_CODES.P -> {
+            // API 28-29: Use BiometricPrompt without setAllowedAuthenticators
+            val prompt =
+                BiometricPrompt.Builder(context)
+                    .setTitle(context.getString(title))
+                    .setNegativeButton(context.getString(R.string.cancel), context.mainExecutor) {
+                        _,
+                        _ ->
+                        //                        Toast.makeText(context, "Authentication
+                        // cancelled", Toast.LENGTH_SHORT)
+                        //                            .show()
+                    }
+                    .build()
+            prompt.authenticate(
+                getCancellationSignal(context),
+                context.mainExecutor,
+                object : BiometricPrompt.AuthenticationCallback() {
+                    override fun onAuthenticationSucceeded(
+                        result: BiometricPrompt.AuthenticationResult?
+                    ) {
+                        super.onAuthenticationSucceeded(result)
+                        onSuccess.invoke()
+                    }
+
+                    override fun onAuthenticationFailed() {
+                        super.onAuthenticationFailed()
+                        onFailure.invoke()
+                    }
+                },
+            )
+        }
+
+        Build.VERSION.SDK_INT >= Build.VERSION_CODES.M -> {
+            // API 23-27: Use FingerprintManager
+            val fingerprintManager =
+                context.getSystemService(Context.FINGERPRINT_SERVICE) as FingerprintManager
+            if (
+                fingerprintManager.isHardwareDetected &&
+                    fingerprintManager.hasEnrolledFingerprints()
+            ) {
+                val cryptoObject: FingerprintManager.CryptoObject? =
+                    null // Setup CryptoObject if needed
+                fingerprintManager.authenticate(
+                    cryptoObject,
+                    getCancellationSignal(context),
+                    0,
+                    object : FingerprintManager.AuthenticationCallback() {
+                        override fun onAuthenticationSucceeded(
+                            result: FingerprintManager.AuthenticationResult?
+                        ) {
+                            super.onAuthenticationSucceeded(result)
+                            onSuccess.invoke()
+                        }
+
+                        override fun onAuthenticationFailed() {
+                            super.onAuthenticationFailed()
+                            onFailure.invoke()
+                        }
+                    },
+                    null,
+                )
+            } else {
+                // No fingerprint available, fallback to PIN
+                promptPinAuthentication(
+                    context,
+                    requestCode,
+                    title,
+                    startActivityForResult,
+                    onFailure,
+                )
+            }
+        }
+
+        else -> {
+            // API 21-22: No biometric support, fallback to PIN/Password
+            promptPinAuthentication(context, requestCode, title, startActivityForResult, onFailure)
+        }
+    }
+}
+
+// Function to handle the cancellation signal
+private fun getCancellationSignal(context: Context): CancellationSignal {
+    return CancellationSignal().apply {
+        setOnCancelListener {
+            //            Toast.makeText(context, "Authentication cancelled",
+            // Toast.LENGTH_SHORT).show()
+        }
+    }
+}
+
+// Function to prompt PIN/Password/Pattern fallback using KeyguardManager
+private fun promptPinAuthentication(
+    context: Context,
+    requestCode: Int,
+    title: Int,
+    startActivityForResult: (intent: Intent, requestCode: Int) -> Unit,
+    onFailure: () -> Unit,
+) {
+    val keyguardManager = context.getSystemService(Context.KEYGUARD_SERVICE) as KeyguardManager
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+        // For API 23 and above, use isDeviceSecure
+        if (keyguardManager.isDeviceSecure) {
+            val intent =
+                keyguardManager.createConfirmDeviceCredentialIntent(context.getString(title), null)
+            if (intent != null) {
+                startActivityForResult(intent, requestCode)
+            } else {
+                onFailure.invoke()
+            }
+        } else {
+            onFailure.invoke()
+        }
+    } else {
+        // For API 21-22, use isKeyguardSecure
+        if (keyguardManager.isKeyguardSecure) {
+            val intent =
+                keyguardManager.createConfirmDeviceCredentialIntent(
+                    "Unlock with PIN",
+                    "Please unlock to proceed",
+                )
+            if (intent != null) {
+                startActivityForResult(intent, requestCode)
+            } else {
+                onFailure.invoke()
+            }
+        } else {
+            onFailure.invoke()
+        }
+    }
+}

--- a/app/src/main/java/com/philkes/notallyx/utils/security/PhoneLockReceiver.kt
+++ b/app/src/main/java/com/philkes/notallyx/utils/security/PhoneLockReceiver.kt
@@ -1,0 +1,15 @@
+package com.philkes.notallyx.utils.security
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import com.philkes.notallyx.NotallyXApplication
+
+class UnlockReceiver(private val application: NotallyXApplication) : BroadcastReceiver() {
+
+    override fun onReceive(context: Context?, intent: Intent) {
+        if (intent.action == Intent.ACTION_SCREEN_OFF) {
+            application.needUnlock = true
+        }
+    }
+}

--- a/app/src/main/java/com/philkes/notallyx/utils/security/PhoneLockReceiver.kt
+++ b/app/src/main/java/com/philkes/notallyx/utils/security/PhoneLockReceiver.kt
@@ -9,7 +9,7 @@ class UnlockReceiver(private val application: NotallyXApplication) : BroadcastRe
 
     override fun onReceive(context: Context?, intent: Intent) {
         if (intent.action == Intent.ACTION_SCREEN_OFF) {
-            application.needUnlock = true
+            application.isLocked = true
         }
     }
 }

--- a/app/src/main/java/com/philkes/notallyx/utils/security/SQLCipherUtils.java
+++ b/app/src/main/java/com/philkes/notallyx/utils/security/SQLCipherUtils.java
@@ -1,0 +1,312 @@
+/*
+ * Copyright (c) 2012-2017 CommonsWare, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.philkes.notallyx.utils.security;
+
+import android.content.Context;
+import android.text.Editable;
+
+import net.sqlcipher.database.SQLiteDatabase;
+import net.sqlcipher.database.SQLiteStatement;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+
+public class SQLCipherUtils {
+    /**
+     * The detected state of the database, based on whether we can open it
+     * without a passphrase.
+     */
+    public enum State {
+        DOES_NOT_EXIST, UNENCRYPTED, ENCRYPTED
+    }
+
+    /**
+     * Determine whether or not this database appears to be encrypted, based
+     * on whether we can open it without a passphrase.
+     *
+     * @param ctxt   a Context
+     * @param dbName the name of the database, as used with Room, SQLiteOpenHelper,
+     *               etc.
+     * @return the detected state of the database
+     */
+    public static State getDatabaseState(Context ctxt, String dbName) {
+        SQLiteDatabase.loadLibs(ctxt);
+
+        return (getDatabaseState(ctxt.getDatabasePath(dbName)));
+    }
+
+    /**
+     * Determine whether or not this database appears to be encrypted, based
+     * on whether we can open it without a passphrase.
+     * <p>
+     * NOTE: You are responsible for ensuring that net.sqlcipher.database.SQLiteDatabase.loadLibs()
+     * is called before calling this method. This is handled automatically with the
+     * getDatabaseState() method that takes a Context as a parameter.
+     *
+     * @param dbPath a File pointing to the database
+     * @return the detected state of the database
+     */
+    public static State getDatabaseState(File dbPath) {
+        if (dbPath.exists()) {
+            SQLiteDatabase db = null;
+
+            try {
+                db =
+                        SQLiteDatabase.openDatabase(dbPath.getAbsolutePath(), "",
+                                null, SQLiteDatabase.OPEN_READONLY);
+
+                db.getVersion();
+
+                return (State.UNENCRYPTED);
+            } catch (Exception e) {
+                return (State.ENCRYPTED);
+            } finally {
+                if (db != null) {
+                    db.close();
+                }
+            }
+        }
+
+        return (State.DOES_NOT_EXIST);
+    }
+
+    /**
+     * Replaces this database with a version encrypted with the supplied
+     * passphrase, deleting the original. Do not call this while the database
+     * is open, which includes during any Room migrations.
+     * <p>
+     * The passphrase is untouched in this call. If you are going to turn around
+     * and use it with SafeHelperFactory.fromUser(), fromUser() will clear the
+     * passphrase. If not, please set all bytes of the passphrase to 0 or something
+     * to clear out the passphrase.
+     *
+     * @param ctxt   a Context
+     * @param dbName the name of the database, as used with Room, SQLiteOpenHelper,
+     *               etc.
+     * @param editor the passphrase, such as obtained by calling getText() on an
+     *               EditText
+     * @throws IOException
+     */
+    public static void encrypt(Context ctxt, String dbName, Editable editor)
+            throws IOException {
+        char[] passphrase = new char[editor.length()];
+
+        editor.getChars(0, editor.length(), passphrase, 0);
+        encrypt(ctxt, dbName, passphrase);
+    }
+
+    /**
+     * Replaces this database with a version encrypted with the supplied
+     * passphrase, deleting the original. Do not call this while the database
+     * is open, which includes during any Room migrations.
+     * <p>
+     * The passphrase is untouched in this call. If you are going to turn around
+     * and use it with SafeHelperFactory.fromUser(), fromUser() will clear the
+     * passphrase. If not, please set all bytes of the passphrase to 0 or something
+     * to clear out the passphrase.
+     *
+     * @param ctxt       a Context
+     * @param dbName     the name of the database, as used with Room, SQLiteOpenHelper,
+     *                   etc.
+     * @param passphrase the passphrase from the user
+     * @throws IOException
+     */
+    public static void encrypt(Context ctxt, String dbName, char[] passphrase)
+            throws IOException {
+        encrypt(ctxt, ctxt.getDatabasePath(dbName), SQLiteDatabase.getBytes(passphrase));
+    }
+
+    /**
+     * Replaces this database with a version encrypted with the supplied
+     * passphrase, deleting the original. Do not call this while the database
+     * is open, which includes during any Room migrations.
+     * <p>
+     * The passphrase is untouched in this call. If you are going to turn around
+     * and use it with SafeHelperFactory.fromUser(), fromUser() will clear the
+     * passphrase. If not, please set all bytes of the passphrase to 0 or something
+     * to clear out the passphrase.
+     *
+     * @param ctxt       a Context
+     * @param dbName     the name of the database, as used with Room, SQLiteOpenHelper,
+     *                   etc.
+     * @param passphrase the passphrase
+     * @throws IOException
+     */
+    public static void encrypt(Context ctxt, String dbName, byte[] passphrase)
+            throws IOException {
+        encrypt(ctxt, ctxt.getDatabasePath(dbName), passphrase);
+    }
+
+    /**
+     * Replaces this database with a version encrypted with the supplied
+     * passphrase, deleting the original. Do not call this while the database
+     * is open, which includes during any Room migrations.
+     * <p>
+     * The passphrase is untouched in this call. If you are going to turn around
+     * and use it with SafeHelperFactory.fromUser(), fromUser() will clear the
+     * passphrase. If not, please set all bytes of the passphrase to 0 or something
+     * to clear out the passphrase.
+     *
+     * @param ctxt         a Context
+     * @param originalFile a File pointing to the database
+     * @param passphrase   the passphrase from the user
+     * @throws IOException
+     */
+    public static void encrypt(Context ctxt, File originalFile, char[] passphrase)
+            throws IOException {
+        encrypt(ctxt, originalFile, SQLiteDatabase.getBytes(passphrase));
+    }
+
+    /**
+     * Replaces this database with a version encrypted with the supplied
+     * passphrase, deleting the original. Do not call this while the database
+     * is open, which includes during any Room migrations.
+     * <p>
+     * The passphrase is untouched in this call. If you are going to turn around
+     * and use it with SafeHelperFactory.fromUser(), fromUser() will clear the
+     * passphrase. If not, please set all bytes of the passphrase to 0 or something
+     * to clear out the passphrase.
+     *
+     * @param ctxt         a Context
+     * @param originalFile a File pointing to the database
+     * @param passphrase   the passphrase from the user
+     * @throws IOException
+     */
+    public static void encrypt(Context ctxt, File originalFile, byte[] passphrase)
+            throws IOException {
+        SQLiteDatabase.loadLibs(ctxt);
+
+        if (originalFile.exists()) {
+            File newFile = File.createTempFile("sqlcipherutils", "tmp",
+                    ctxt.getCacheDir());
+            SQLiteDatabase db =
+                    SQLiteDatabase.openDatabase(originalFile.getAbsolutePath(),
+                            "", null, SQLiteDatabase.OPEN_READWRITE);
+            int version = db.getVersion();
+
+            db.close();
+
+            db = SQLiteDatabase.openDatabase(newFile.getAbsolutePath(), passphrase,
+                    null, SQLiteDatabase.OPEN_READWRITE, null, null);
+
+            final SQLiteStatement st = db.compileStatement("ATTACH DATABASE ? AS plaintext KEY ''");
+
+            st.bindString(1, originalFile.getAbsolutePath());
+            st.execute();
+
+            db.rawExecSQL("SELECT sqlcipher_export('main', 'plaintext')");
+            db.rawExecSQL("DETACH DATABASE plaintext");
+            db.setVersion(version);
+            st.close();
+            db.close();
+
+            originalFile.delete();
+            newFile.renameTo(originalFile);
+        } else {
+            throw new FileNotFoundException(originalFile.getAbsolutePath() + " not found");
+        }
+    }
+
+    /**
+     * Replaces this database with a decrypted version, deleting the original
+     * encrypted database. Do not call this while the database is open, which
+     * includes during any Room migrations.
+     * <p>
+     * The passphrase is untouched in this call. Please set all bytes of the
+     * passphrase to 0 or something to clear out the passphrase if you are done
+     * with it.
+     *
+     * @param ctxt         a Context
+     * @param originalFile a File pointing to the encrypted database
+     * @param passphrase   the passphrase from the user for the encrypted database
+     * @throws IOException
+     */
+    public static void decrypt(Context ctxt, File originalFile, char[] passphrase)
+            throws IOException {
+        decrypt(ctxt, originalFile, SQLiteDatabase.getBytes(passphrase));
+    }
+
+    public static void decrypt(Context ctxt, String dbName, byte[] passphrase) throws IOException {
+        decrypt(ctxt, ctxt.getDatabasePath(dbName), passphrase);
+    }
+
+    public static void decrypt(Context ctxt, String dbName, File decryptedFile, byte[] passphrase) throws IOException {
+        decrypt(ctxt, ctxt.getDatabasePath(dbName), decryptedFile, passphrase);
+    }
+
+    /**
+     * Replaces this database with a decrypted version, deleting the original
+     * encrypted database. Do not call this while the database is open, which
+     * includes during any Room migrations.
+     * <p>
+     * The passphrase is untouched in this call. Please set all bytes of the
+     * passphrase to 0 or something to clear out the passphrase if you are done
+     * with it.
+     *
+     * @param ctxt         a Context
+     * @param originalFile a File pointing to the encrypted database
+     * @param passphrase   the passphrase from the user for the encrypted database
+     * @throws IOException
+     */
+    public static void decrypt(Context ctxt, File originalFile, byte[] passphrase)
+            throws IOException {
+
+        if (originalFile.exists()) {
+            File newFile =
+                    File.createTempFile("sqlcipherutils", "tmp",
+                            ctxt.getCacheDir());
+            decrypt(ctxt, originalFile, newFile, passphrase);
+            originalFile.delete();
+            newFile.renameTo(originalFile);
+        }
+
+    }
+
+    public static void decrypt(Context ctxt, File originalFile, File decryptedFile, byte[] passphrase) throws IOException {
+        SQLiteDatabase.loadLibs(ctxt);
+
+        if (originalFile.exists()) {
+            SQLiteDatabase db =
+                    SQLiteDatabase.openDatabase(originalFile.getAbsolutePath(),
+                            passphrase, null, SQLiteDatabase.OPEN_READWRITE, null, null);
+
+            final SQLiteStatement st = db.compileStatement("ATTACH DATABASE ? AS plaintext KEY ''");
+
+            if (!decryptedFile.exists()) {
+                decryptedFile.createNewFile();
+            }
+            st.bindString(1, decryptedFile.getAbsolutePath());
+            st.execute();
+
+            db.rawExecSQL("SELECT sqlcipher_export('plaintext')");
+            db.rawExecSQL("DETACH DATABASE plaintext");
+
+            int version = db.getVersion();
+
+            st.close();
+            db.close();
+
+            db = SQLiteDatabase.openDatabase(decryptedFile.getAbsolutePath(), "",
+                    null, SQLiteDatabase.OPEN_READWRITE);
+            db.setVersion(version);
+            db.close();
+        } else {
+            throw new FileNotFoundException(originalFile.getAbsolutePath() + " not found");
+        }
+    }
+}

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -108,6 +108,21 @@
             style="@style/PreferenceHeader"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:text="@string/security" />
+
+        <include
+            android:id="@+id/BiometricLock"
+            layout="@layout/preference" />
+
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:background="?android:attr/listDivider" />
+
+        <TextView
+            style="@style/PreferenceHeader"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
             android:text="@string/about" />
 
         <TextView

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -57,6 +57,7 @@
     <string name="delete_selected_notes">Delete selected notes?</string>
     <string name="delete_note_forever">Delete note forever?</string>
     <string name="your_notes_associated">Your notes attached to this label will not be deleted</string>
+    <string name="biometrics_setup_success">Biometric/PIN lock has been enabled</string>
 
     <!-- Snackbars -->
     <plurals name="deleted_selected_notes">
@@ -142,6 +143,13 @@
     <string name="max_items_to_display">Max items to display in list</string>
     <string name="max_lines_to_display">Max lines to display in note</string>
     <string name="max_lines_to_display_title">Max lines to display in title</string>
+
+
+    <string name="security">Security</string>
+
+    <string name="biometric_lock">Lock app with device biometric or PIN</string>
+    <string name="enabled">Enabled</string>
+    <string name="disabled">Disabled</string>
 
     <!-- Backup -->
     <string name="backup">Backup</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -58,6 +58,8 @@
     <string name="delete_note_forever">Delete note forever?</string>
     <string name="your_notes_associated">Your notes attached to this label will not be deleted</string>
     <string name="biometrics_setup_success">Biometric/PIN lock has been enabled</string>
+    <string name="biometrics_disable_success">Biometric/PIN lock has been disabled</string>
+    <string name="biometrics_failure">Failed to authenticate vai Biometric/PIN</string>
 
     <!-- Snackbars -->
     <plurals name="deleted_selected_notes">
@@ -244,6 +246,9 @@
 
     <!-- Lock -->
     <string name="enable_lock_title">Enable lock via Biometric/PIN</string>
+    <string name="enable_lock_description">This will also encrypt the database</string>
+    <string name="disable_lock_title">Disable lock via Biometric/PIN</string>
+    <string name="disable_lock_description">This will also decrypt the database</string>
     <string name="unlock">Unlock via Biometric/PIN</string>
     <string name="biometrics_no_support">No biometric features available on this device</string>
     <string name="biometrics_not_setup">Biometrics/PIN are not setup for your device yet</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -241,4 +241,11 @@
     <string name="please_grant_notally_audio">Please grant NotallyX the permission to record audio. Recordings never leave your device</string>
     <string name="insert_an_sd_card_audio">Insert an SD card to record audio</string>
     <string name="something_went_wrong_audio">Something went wrong. The audio recording may have been moved or deleted.\n\nError : (%1$d, %2$d)</string>
+
+    <!-- Lock -->
+    <string name="enable_lock_title">Enable lock via Biometric/PIN</string>
+    <string name="unlock">Unlock via Biometric/PIN</string>
+    <string name="biometrics_no_support">No biometric features available on this device</string>
+    <string name="biometrics_not_setup">Biometrics/PIN are not setup for your device yet</string>
+
 </resources>


### PR DESCRIPTION
Closes #30 

* New preference for enabling/disabling lock:

 [notallyx_issues_30_1.webm](https://github.com/user-attachments/assets/a6b0731d-6fb5-4893-8197-a4590f3ea6bd)

Note: If the user has no HW support for biometrics a Toast is shown. If the user hasnt setup biometrics/pin yet he will be navigated to the device settings for that

* User has to unlock on first app start and after device has been locked

[notallyx_issues_30.webm](https://github.com/user-attachments/assets/411db642-36e3-4e5a-a03d-25887f4b75d0)

* When the user enables the lock the database is also encrypted
* For backups, if the lock is enabled the backups copy a decrypted database into the `zip`

* TODO:
* Preference for setting time after which the user has to unlock again?
* As you can see in the video when locking the device and then unlocking with the app immediately open again the Views are shown very briefly. I do not know why yet, since I change the Visibility of all views in `onPause` to `INVISIBLE`and only set it to `VISIBLE` again AFTER the biometric/pin prompt. No idea where this behaviour is coming from.