### PR TITLE
Add text formatting to ChangeHistory and fix Clear Formatting action

### DIFF
--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/note/EditNoteActivity.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/note/EditNoteActivity.kt
@@ -6,7 +6,6 @@ import android.net.Uri
 import android.text.Editable
 import android.text.Spanned
 import android.text.TextWatcher
-import android.text.style.CharacterStyle
 import android.text.style.StrikethroughSpan
 import android.text.style.StyleSpan
 import android.text.style.TypefaceSpan
@@ -15,14 +14,17 @@ import android.util.Patterns
 import android.view.ActionMode
 import android.view.Menu
 import android.view.MenuItem
+import android.widget.EditText
 import android.widget.Toast
-import androidx.core.text.getSpans
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.philkes.notallyx.R
 import com.philkes.notallyx.data.model.Type
 import com.philkes.notallyx.utils.LinkMovementMethod
 import com.philkes.notallyx.utils.add
+import com.philkes.notallyx.utils.changehistory.EditTextChange
+import com.philkes.notallyx.utils.clone
 import com.philkes.notallyx.utils.createTextWatcherWithHistory
+import com.philkes.notallyx.utils.removeSelectionFromSpan
 import com.philkes.notallyx.utils.setOnNextAction
 
 class EditNoteActivity : EditActivity(Type.NOTE) {
@@ -42,8 +44,8 @@ class EditNoteActivity : EditActivity(Type.NOTE) {
     override fun setupListeners() {
         super.setupListeners()
         enterBodyTextWatcher = run {
-            binding.EnterBody.createTextWatcherWithHistory(changeHistory) { text: String ->
-                model.body = Editable.Factory.getInstance().newEditable(text)
+            binding.EnterBody.createTextWatcherWithHistory(changeHistory) { text: Editable ->
+                model.body = text.clone()
             }
         }
         binding.EnterBody.addTextChangedListener(enterBodyTextWatcher)
@@ -99,7 +101,7 @@ class EditNoteActivity : EditActivity(Type.NOTE) {
                                     mode?.finish()
                                 }
                                 add(R.string.clear_formatting, 0) {
-                                    removeSpans()
+                                    clearFormatting()
                                     mode?.finish()
                                 }
                             }
@@ -112,6 +114,7 @@ class EditNoteActivity : EditActivity(Type.NOTE) {
 
                 override fun onDestroyActionMode(mode: ActionMode?) {
                     binding.EnterBody.isActionModeOn = false
+                    model.body = binding.EnterBody.text!!.clone()
                 }
             }
     }
@@ -147,23 +150,28 @@ class EditNoteActivity : EditActivity(Type.NOTE) {
         binding.EnterBody.movementMethod = movementMethod
     }
 
-    private fun removeSpans() {
-        val selectionEnd = binding.EnterBody.selectionEnd
-        val selectionStart = binding.EnterBody.selectionStart
-
-        ifBothNotNullAndInvalid(selectionStart, selectionEnd) { start, end ->
-            binding.EnterBody.text?.getSpans<CharacterStyle>(start, end)?.forEach { span ->
-                binding.EnterBody.text?.removeSpan(span)
-            }
+    private fun clearFormatting() {
+        binding.EnterBody.changeFormatting { start, end, text ->
+            text.removeSelectionFromSpan(start, end)
         }
     }
 
     private fun applySpan(span: Any) {
-        val selectionEnd = binding.EnterBody.selectionEnd
-        val selectionStart = binding.EnterBody.selectionStart
+        binding.EnterBody.changeFormatting { start, end, text ->
+            text.setSpan(span, start, end, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+        }
+    }
 
+    private fun EditText.changeFormatting(change: (start: Int, end: Int, text: Editable) -> Unit) {
         ifBothNotNullAndInvalid(selectionStart, selectionEnd) { start, end ->
-            binding.EnterBody.text?.setSpan(span, start, end, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+            val textBefore = text!!.clone()
+            change(start, end, text)
+            val textAfter = text!!.clone()
+            changeHistory.push(
+                EditTextChange(this, textBefore, textAfter, enterBodyTextWatcher) { text ->
+                    model.body = text.clone()
+                }
+            )
         }
     }
 

--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/note/EditNoteActivity.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/note/EditNoteActivity.kt
@@ -14,6 +14,7 @@ import android.util.Patterns
 import android.view.ActionMode
 import android.view.Menu
 import android.view.MenuItem
+import android.view.inputmethod.InputMethodManager
 import android.widget.EditText
 import android.widget.Toast
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
@@ -117,6 +118,15 @@ class EditNoteActivity : EditActivity(Type.NOTE) {
                     model.body = binding.EnterBody.text!!.clone()
                 }
             }
+
+        binding.ContentLayout.setOnClickListener {
+            binding.EnterBody.apply {
+                requestFocus()
+                setSelection(text!!.length)
+                val imm = getSystemService(INPUT_METHOD_SERVICE) as InputMethodManager
+                imm.showSoftInput(this, InputMethodManager.SHOW_IMPLICIT)
+            }
+        }
     }
 
     private fun setupMovementMethod() {

--- a/app/src/main/java/com/philkes/notallyx/utils/changehistory/EditTextChange.kt
+++ b/app/src/main/java/com/philkes/notallyx/utils/changehistory/EditTextChange.kt
@@ -1,24 +1,25 @@
 package com.philkes.notallyx.utils.changehistory
 
+import android.text.Editable
 import android.text.TextWatcher
 import android.widget.EditText
 
 class EditTextChange(
     private val editText: EditText,
-    textBefore: String,
-    textAfter: String,
+    textBefore: Editable,
+    textAfter: Editable,
     private val listener: TextWatcher,
-    private val updateModel: (newValue: String) -> Unit,
-) : ValueChange<String>(textAfter, textBefore) {
+    private val updateModel: (newValue: Editable) -> Unit,
+) : ValueChange<Editable>(textAfter, textBefore) {
 
     private val cursorPosition = editText.selectionStart
 
-    override fun update(value: String, isUndo: Boolean) {
-        updateModel.invoke(value)
+    override fun update(value: Editable, isUndo: Boolean) {
         editText.removeTextChangedListener(listener)
-        editText.setText(value)
+        updateModel.invoke(value)
+        editText.text = value
         editText.requestFocus()
-        editText.setSelection(Math.max(0, cursorPosition - (if (isUndo) 1 else 0)))
+        editText.setSelection(Math.min(value.length, cursorPosition + (if (isUndo) 1 else 0)))
         editText.addTextChangedListener(listener)
     }
 }

--- a/app/src/main/java/com/philkes/notallyx/utils/changehistory/ValueChange.kt
+++ b/app/src/main/java/com/philkes/notallyx/utils/changehistory/ValueChange.kt
@@ -7,7 +7,7 @@ abstract class ValueChange<T>(protected val newValue: T, protected val oldValue:
     }
 
     override fun undo() {
-        update(newValue, true)
+        update(oldValue, true)
     }
 
     abstract fun update(value: T, isUndo: Boolean)

--- a/app/src/main/res/layout/activity_edit.xml
+++ b/app/src/main/res/layout/activity_edit.xml
@@ -21,9 +21,11 @@
         android:visibility="gone">
 
         <LinearLayout
+            android:id="@+id/ContentLayout"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:focusableInTouchMode="true"
+            android:focusable="false"
+            android:focusableInTouchMode="false"
             android:orientation="vertical"
             android:paddingBottom="16dp">
 


### PR DESCRIPTION
Closes #47 

* Adds all formatting changes to `ChangeHistory`
* Reworks the `Clear Formatting` action, so that it does not simply delete the whole formatted `Span` but instead only removes the selected text from the `Span`
* If you click outside of the `EditText` in `EditNoteActivity` the `EditText` is automatically focused