### PR TITLE
Rework pasting Link and editing

### DIFF
--- a/app/src/main/java/com/philkes/notallyx/data/model/Converters.kt
+++ b/app/src/main/java/com/philkes/notallyx/data/model/Converters.kt
@@ -63,12 +63,13 @@ object Converters {
         return iterable.map { jsonObject ->
             val bold = jsonObject.getSafeBoolean("bold")
             val link = jsonObject.getSafeBoolean("link")
+            val linkData = jsonObject.getSafeString("linkData")
             val italic = jsonObject.getSafeBoolean("italic")
             val monospace = jsonObject.getSafeBoolean("monospace")
             val strikethrough = jsonObject.getSafeBoolean("strikethrough")
             val start = jsonObject.getInt("start")
             val end = jsonObject.getInt("end")
-            SpanRepresentation(bold, link, italic, monospace, strikethrough, start, end)
+            SpanRepresentation(bold, link, linkData, italic, monospace, strikethrough, start, end)
         }
     }
 
@@ -107,6 +108,7 @@ object Converters {
                 val jsonObject = JSONObject()
                 jsonObject.put("bold", representation.bold)
                 jsonObject.put("link", representation.link)
+                jsonObject.put("linkData", representation.linkData)
                 jsonObject.put("italic", representation.italic)
                 jsonObject.put("monospace", representation.monospace)
                 jsonObject.put("strikethrough", representation.strikethrough)
@@ -137,6 +139,14 @@ object Converters {
             getBoolean(name)
         } catch (exception: JSONException) {
             false
+        }
+    }
+
+    private fun JSONObject.getSafeString(name: String): String? {
+        return try {
+            getString(name)
+        } catch (exception: JSONException) {
+            null
         }
     }
 

--- a/app/src/main/java/com/philkes/notallyx/data/model/SpanRepresentation.kt
+++ b/app/src/main/java/com/philkes/notallyx/data/model/SpanRepresentation.kt
@@ -3,6 +3,7 @@ package com.philkes.notallyx.data.model
 data class SpanRepresentation(
     var bold: Boolean,
     var link: Boolean,
+    var linkData: String?,
     var italic: Boolean,
     var monospace: Boolean,
     var strikethrough: Boolean,

--- a/app/src/main/java/com/philkes/notallyx/presentation/viewmodel/NotallyModel.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/viewmodel/NotallyModel.kt
@@ -425,7 +425,8 @@ class NotallyModel(private val app: Application) : AndroidViewModel(app) {
         spanned.getSpans<CharacterStyle>().forEach { span ->
             val end = spanned.getSpanEnd(span)
             val start = spanned.getSpanStart(span)
-            val representation = SpanRepresentation(false, false, false, false, false, start, end)
+            val representation =
+                SpanRepresentation(false, false, null, false, false, false, start, end)
 
             when (span) {
                 is StyleSpan -> {
@@ -433,7 +434,10 @@ class NotallyModel(private val app: Application) : AndroidViewModel(app) {
                     representation.italic = span.style == Typeface.ITALIC
                 }
 
-                is URLSpan -> representation.link = true
+                is URLSpan -> {
+                    representation.link = true
+                    representation.linkData = span.url
+                }
                 is TypefaceSpan -> representation.monospace = span.family == "monospace"
                 is StrikethroughSpan -> representation.strikethrough = true
             }
@@ -459,6 +463,7 @@ class NotallyModel(private val app: Application) : AndroidViewModel(app) {
                 }
                 if (match.link) {
                     representation.link = true
+                    representation.linkData = match.linkData
                 }
                 if (match.italic) {
                     representation.italic = true

--- a/app/src/main/java/com/philkes/notallyx/utils/backup/XMLUtils.kt
+++ b/app/src/main/java/com/philkes/notallyx/utils/backup/XMLUtils.kt
@@ -146,9 +146,19 @@ object XMLUtils {
         val end = parser.getAttributeValue(null, "end").toInt()
         val bold = parser.getAttributeValue(null, "bold")?.toBoolean() ?: false
         val link = parser.getAttributeValue(null, "link")?.toBoolean() ?: false
+        val linkData = parser.getAttributeValue(null, "linkData")?.toString()
         val italic = parser.getAttributeValue(null, "italic")?.toBoolean() ?: false
         val monospace = parser.getAttributeValue(null, "monospace")?.toBoolean() ?: false
         val strikethrough = parser.getAttributeValue(null, "strike")?.toBoolean() ?: false
-        return SpanRepresentation(bold, link, italic, monospace, strikethrough, start, end)
+        return SpanRepresentation(
+            bold,
+            link,
+            linkData,
+            italic,
+            monospace,
+            strikethrough,
+            start,
+            end,
+        )
     }
 }

--- a/app/src/main/res/layout/update_link_dialog.xml
+++ b/app/src/main/res/layout/update_link_dialog.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:paddingTop="8dp"
+    android:paddingStart="24dp"
+    android:paddingEnd="24dp"
+    >
+
+    <EditText
+        android:id="@+id/InputText"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textSize="16sp"
+        android:paddingBottom="8dp"
+        android:layout_marginTop="12dp"
+        />
+
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -40,6 +40,7 @@
     <!-- Dialogs -->
     <string name="save">Save</string>
     <string name="edit">Edit</string>
+    <string name="copy">Copy</string>
     <string name="cancel">Cancel</string>
     <string name="continue_">Continue</string>
     <string name="open_link">Open link</string>
@@ -104,6 +105,10 @@
 
     <!-- Messages -->
     <string name="cant_open_link">Can’t open link</string>
+    <string name="invalid_link">Copy a valid link into your clipboard</string>
+    <string name="updated_link">Updated Link</string>
+    <string name="copied_link">Copied Link to Clipboard</string>
+    <string name="edit_link">Edit Link</string>
     <string name="something_went_wrong">Something went wrong. Please try again.</string>
     <string name="install_an_email">Install an email app to send feedback</string>
     <string name="install_a_browser">Install a browser to open this link</string>


### PR DESCRIPTION
Closes #40 

* When pasting a URL it will automatically be inserted as a clickable `URLSpan`
*  Added `Copy` action when you click on a link
* When a text is selected and you choose `Link` in the ActionContextMenu the Text is transformed into a `URLSpan` with a link to the URL in your Clipboard
* You can edit the URL of a Link with the `Edit` action when you click a Link

[notally_issues_40.webm](https://github.com/user-attachments/assets/1c4b10fb-9e03-4502-830d-f4ddd14f284e)
