### PR TITLE
Add EditActivity title EditText to ChangeHistory

### DIFF
--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/note/EditListActivity.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/note/EditListActivity.kt
@@ -26,6 +26,7 @@ class EditListActivity : EditActivity(Type.LIST) {
     private lateinit var listManager: ListManager
 
     override suspend fun saveNote() {
+        super.saveNote()
         model.saveNote(items.toMutableList())
         WidgetProvider.sendBroadcast(application, longArrayOf(model.id))
     }

--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/note/EditNoteActivity.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/note/EditNoteActivity.kt
@@ -24,6 +24,7 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.philkes.notallyx.R
 import com.philkes.notallyx.data.model.Type
 import com.philkes.notallyx.databinding.TextInputDialogBinding
+import com.philkes.notallyx.presentation.widget.WidgetProvider
 import com.philkes.notallyx.utils.LinkMovementMethod
 import com.philkes.notallyx.utils.add
 import com.philkes.notallyx.utils.changehistory.EditTextChange
@@ -36,6 +37,12 @@ import com.philkes.notallyx.utils.showKeyboard
 class EditNoteActivity : EditActivity(Type.NOTE) {
 
     private lateinit var enterBodyTextWatcher: TextWatcher
+
+    override suspend fun saveNote() {
+        super.saveNote()
+        model.saveNote()
+        WidgetProvider.sendBroadcast(application, longArrayOf(model.id))
+    }
 
     override fun configureUI() {
         binding.EnterTitle.setOnNextAction { binding.EnterBody.requestFocus() }

--- a/app/src/main/java/com/philkes/notallyx/presentation/widget/WidgetFactory.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/widget/WidgetFactory.kt
@@ -67,10 +67,7 @@ class WidgetFactory(private val app: Application, private val id: Long, private 
                 TypedValue.COMPLEX_UNIT_SP,
                 TextSize.getDisplayTitleSize(preferences.textSize.value),
             )
-            if (note.title.isNotEmpty()) {
-                setTextViewText(R.id.Title, note.title)
-                setViewVisibility(R.id.Title, View.VISIBLE)
-            } else setViewVisibility(R.id.Title, View.GONE)
+            setTextViewText(R.id.Title, note.title)
 
             val bodyTextSize = TextSize.getDisplayBodySize(preferences.textSize.value)
 
@@ -97,10 +94,7 @@ class WidgetFactory(private val app: Application, private val id: Long, private 
                 TypedValue.COMPLEX_UNIT_SP,
                 TextSize.getDisplayTitleSize(preferences.textSize.value),
             )
-            if (list.title.isNotEmpty()) {
-                setTextViewText(R.id.Title, list.title)
-                setViewVisibility(R.id.Title, View.VISIBLE)
-            } else setViewVisibility(R.id.Title, View.GONE)
+            setTextViewText(R.id.Title, list.title)
 
             val bodyTextSize = TextSize.getDisplayBodySize(preferences.textSize.value)
 


### PR DESCRIPTION
Fixes #61 
* Changes to the title `EditText` are now added to the `ChangeHistory`, thereby the modified timestamp is also updated when only the title was modified  

[notallyx_issues_61.webm](https://github.com/user-attachments/assets/7e0053da-2b32-46f3-90b6-f2007aea51fb)
