### PR TITLE
Finish LockedActivity for any authentication error

### DIFF
--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/LockedActivity.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/LockedActivity.kt
@@ -49,9 +49,13 @@ abstract class LockedActivity<T : ViewBinding> : AppCompatActivity() {
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         super.onActivityResult(requestCode, resultCode, data)
-        if (requestCode == REQUEST_BIOMETRIC_AUTHENTICATION && resultCode == Activity.RESULT_OK) {
-            notallyXApplication.isLocked = false
-            show()
+        if (requestCode == REQUEST_BIOMETRIC_AUTHENTICATION) {
+            if (resultCode == Activity.RESULT_OK) {
+                notallyXApplication.isLocked = false
+                show()
+            } else {
+                finish()
+            }
         }
     }
 

--- a/app/src/main/java/com/philkes/notallyx/utils/security/LockUtils.kt
+++ b/app/src/main/java/com/philkes/notallyx/utils/security/LockUtils.kt
@@ -108,6 +108,11 @@ private fun showBiometricOrPinPrompt(
                         super.onAuthenticationFailed()
                         onFailure.invoke()
                     }
+
+                    override fun onAuthenticationError(errorCode: Int, errString: CharSequence?) {
+                        super.onAuthenticationError(errorCode, errString)
+                        onFailure.invoke()
+                    }
                 },
             )
         }
@@ -138,6 +143,14 @@ private fun showBiometricOrPinPrompt(
 
                         override fun onAuthenticationFailed() {
                             super.onAuthenticationFailed()
+                            onFailure.invoke()
+                        }
+
+                        override fun onAuthenticationError(
+                            errorCode: Int,
+                            errString: CharSequence?,
+                        ) {
+                            super.onAuthenticationError(errorCode, errString)
                             onFailure.invoke()
                         }
                     },


### PR DESCRIPTION
Fixes #58 
* Call `LockedActivity.finish()` for **any** authentication error during Biometric/PIN unlock

[notallyx_issues_58.webm](https://github.com/user-attachments/assets/328985c1-d24c-4db0-8159-da61f4e8c0c0)

(1st time Android back button was pressed when unlock is shown)