### PR TITLE
Allow to swipe on ListItemVH DragHandle

### DIFF
--- a/app/src/main/java/com/philkes/notallyx/presentation/view/note/listitem/ListItemDragCallback.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/view/note/listitem/ListItemDragCallback.kt
@@ -99,7 +99,9 @@ class ListItemDragCallback(private val elevation: Float, private val listManager
     internal fun onDragStart(viewHolder: ViewHolder, recyclerView: RecyclerView) {
         Log.d(TAG, "onDragStart")
         reset()
-
+        if (viewHolder.adapterPosition == -1) {
+            return
+        }
         val item = listManager.getItem(viewHolder.adapterPosition)
         if (!item.isChild) {
             childViewHolders =

--- a/app/src/main/java/com/philkes/notallyx/presentation/view/note/listitem/ListItemVH.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/view/note/listitem/ListItemVH.kt
@@ -26,6 +26,7 @@ class ListItemVH(
 ) : RecyclerView.ViewHolder(binding.root) {
 
     private var editTextWatcher: TextWatcher
+    private var dragHandleInitialY: Float = 0f
 
     init {
         val body = TextSize.getEditBodySize(textSize)
@@ -47,8 +48,15 @@ class ListItemVH(
         }
 
         binding.DragHandle.setOnTouchListener { _, event ->
-            if (event.actionMasked == MotionEvent.ACTION_DOWN) {
-                touchHelper.startDrag(this)
+            when (event.actionMasked) {
+                MotionEvent.ACTION_DOWN -> dragHandleInitialY = event.y
+                MotionEvent.ACTION_MOVE,
+                MotionEvent.ACTION_CANCEL -> {
+                    val dY = Math.abs(dragHandleInitialY!! - event.y)
+                    if (dY > binding.DragHandle.measuredHeight * 0.15f) {
+                        touchHelper.startDrag(this)
+                    }
+                }
             }
             false
         }

--- a/app/src/main/res/layout/activity_edit.xml
+++ b/app/src/main/res/layout/activity_edit.xml
@@ -121,6 +121,8 @@
                 android:clipToPadding="false"
                 android:overScrollMode="never"
                 android:paddingTop="4dp"
+                android:paddingStart="14dp"
+                android:paddingEnd="14dp"
                 app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />
 
             <TextView


### PR DESCRIPTION
Fixes #67 

* Allows to swipe a `ListItemVH` on the `DragHandle`:

[notallyx_issues_67.webm](https://github.com/user-attachments/assets/d086a1c2-edc4-4b2a-bc74-af844f98613d)


Note: If you already started a swipe to left/right you cant start a up/down drag in the same Drag motion, since this would mean fusing the `SwipeLayout` and `ListItemDragCallback` together, which takes much more effort