### PR TITLE
Align displayed date with sort by preference

### DIFF
--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/ConfigureWidgetActivity.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/ConfigureWidgetActivity.kt
@@ -50,6 +50,7 @@ class ConfigureWidgetActivity : LockedActivity<ActivityConfigureWidgetBinding>()
                 BaseNoteAdapter(
                     Collections.emptySet(),
                     dateFormat.value,
+                    notesSorting.value.first,
                     textSize.value,
                     maxItems,
                     maxLines,

--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/ConfigureWidgetActivity.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/ConfigureWidgetActivity.kt
@@ -84,6 +84,10 @@ class ConfigureWidgetActivity : LockedActivity<ActivityConfigureWidgetBinding>()
                 adapter.submitList(notes)
             }
         }
+
+        preferences.notesSorting.observe(this) { (sortBy, sortDirection) ->
+            adapter.setSorting(sortBy, sortDirection)
+        }
     }
 
     override fun onClick(position: Int) {

--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/main/fragment/NotallyFragment.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/main/fragment/NotallyFragment.kt
@@ -131,6 +131,7 @@ abstract class NotallyFragment : Fragment(), ListItemListener {
                 BaseNoteAdapter(
                     model.actionMode.selectedIds,
                     dateFormat.value,
+                    notesSorting.value.first,
                     textSize.value,
                     maxItems,
                     maxLines,

--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/note/EditActivity.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/note/EditActivity.kt
@@ -35,6 +35,7 @@ import com.philkes.notallyx.databinding.ActivityEditBinding
 import com.philkes.notallyx.databinding.DialogProgressBinding
 import com.philkes.notallyx.presentation.activity.LockedActivity
 import com.philkes.notallyx.presentation.view.Constants
+import com.philkes.notallyx.presentation.view.misc.NotesSorting.autoSortByCreationDate
 import com.philkes.notallyx.presentation.view.misc.NotesSorting.autoSortByModifiedDate
 import com.philkes.notallyx.presentation.view.misc.TextSize
 import com.philkes.notallyx.presentation.view.note.ErrorAdapter
@@ -252,14 +253,11 @@ abstract class EditActivity(private val type: Type) : LockedActivity<ActivityEdi
     open fun setStateFromModel() {
         val (date, datePrefixResId) =
             when (preferences.notesSorting.value.first) {
+                autoSortByCreationDate -> Pair(model.timestamp, R.string.creation_date)
                 autoSortByModifiedDate -> Pair(model.modifiedTimestamp, R.string.modified_date)
-                else -> Pair(model.timestamp, R.string.creation_date)
+                else -> Pair(null, null)
             }
-        binding.Date.displayFormattedTimestamp(
-            date,
-            preferences.dateFormat.value,
-            prefixResId = datePrefixResId,
-        )
+        binding.Date.displayFormattedTimestamp(date, preferences.dateFormat.value, datePrefixResId)
 
         updateEnterTitle()
         Operations.bindLabels(binding.LabelGroup, model.labels, model.textSize)

--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/note/EditActivity.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/note/EditActivity.kt
@@ -35,6 +35,7 @@ import com.philkes.notallyx.databinding.ActivityEditBinding
 import com.philkes.notallyx.databinding.DialogProgressBinding
 import com.philkes.notallyx.presentation.activity.LockedActivity
 import com.philkes.notallyx.presentation.view.Constants
+import com.philkes.notallyx.presentation.view.misc.NotesSorting.autoSortByModifiedDate
 import com.philkes.notallyx.presentation.view.misc.TextSize
 import com.philkes.notallyx.presentation.view.note.ErrorAdapter
 import com.philkes.notallyx.presentation.view.note.audio.AudioAdapter
@@ -249,7 +250,17 @@ abstract class EditActivity(private val type: Type) : LockedActivity<ActivityEdi
     }
 
     open fun setStateFromModel() {
-        binding.DateCreated.displayFormattedTimestamp(model.timestamp, preferences.dateFormat.value)
+        val (date, datePrefixResId) =
+            when (preferences.notesSorting.value.first) {
+                autoSortByModifiedDate -> Pair(model.modifiedTimestamp, R.string.modified_date)
+                else -> Pair(model.timestamp, R.string.creation_date)
+            }
+        binding.Date.displayFormattedTimestamp(
+            date,
+            preferences.dateFormat.value,
+            prefixResId = datePrefixResId,
+        )
+
         updateEnterTitle()
         Operations.bindLabels(binding.LabelGroup, model.labels, model.textSize)
 
@@ -594,7 +605,7 @@ abstract class EditActivity(private val type: Type) : LockedActivity<ActivityEdi
         val body = TextSize.getEditBodySize(model.textSize)
 
         binding.EnterTitle.setTextSize(TypedValue.COMPLEX_UNIT_SP, title)
-        binding.DateCreated.setTextSize(TypedValue.COMPLEX_UNIT_SP, date)
+        binding.Date.setTextSize(TypedValue.COMPLEX_UNIT_SP, date)
         binding.EnterBody.setTextSize(TypedValue.COMPLEX_UNIT_SP, body)
 
         setupImages()

--- a/app/src/main/java/com/philkes/notallyx/presentation/view/main/BaseNoteAdapter.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/view/main/BaseNoteAdapter.kt
@@ -22,6 +22,7 @@ import java.io.File
 class BaseNoteAdapter(
     private val selectedIds: Set<Long>,
     private val dateFormat: String,
+    private val sortedBy: String,
     private val textSize: String,
     private val maxItems: Int,
     private val maxLines: Int,
@@ -48,7 +49,12 @@ class BaseNoteAdapter(
         when (val item = list[position]) {
             is Header -> (holder as HeaderVH).bind(item)
             is BaseNote ->
-                (holder as BaseNoteVH).bind(item, imageRoot, selectedIds.contains(item.id))
+                (holder as BaseNoteVH).bind(
+                    item,
+                    imageRoot,
+                    selectedIds.contains(item.id),
+                    sortedBy,
+                )
         }
     }
 

--- a/app/src/main/java/com/philkes/notallyx/presentation/view/main/BaseNoteVH.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/view/main/BaseNoteVH.kt
@@ -24,6 +24,7 @@ import com.philkes.notallyx.data.model.ListItem
 import com.philkes.notallyx.data.model.SpanRepresentation
 import com.philkes.notallyx.data.model.Type
 import com.philkes.notallyx.databinding.RecyclerBaseNoteBinding
+import com.philkes.notallyx.presentation.view.misc.NotesSorting.autoSortByCreationDate
 import com.philkes.notallyx.presentation.view.misc.NotesSorting.autoSortByModifiedDate
 import com.philkes.notallyx.presentation.view.misc.TextSize
 import com.philkes.notallyx.presentation.view.note.listitem.ListItemListener
@@ -74,7 +75,7 @@ class BaseNoteVH(
         binding.root.isChecked = checked
     }
 
-    fun bind(baseNote: BaseNote, imageRoot: File?, checked: Boolean, sortingKey: String) {
+    fun bind(baseNote: BaseNote, imageRoot: File?, checked: Boolean, sortBy: String) {
         updateCheck(checked)
 
         when (baseNote.type) {
@@ -82,11 +83,13 @@ class BaseNoteVH(
             Type.LIST -> bindList(baseNote.items)
         }
         val (date, datePrefixResId) =
-            when (sortingKey) {
+            when (sortBy) {
+                autoSortByCreationDate -> Pair(baseNote.timestamp, R.string.creation_date)
                 autoSortByModifiedDate -> Pair(baseNote.modifiedTimestamp, R.string.modified_date)
-                else -> Pair(baseNote.timestamp, R.string.creation_date)
+                else -> Pair(null, null)
             }
-        binding.Date.displayFormattedTimestamp(date, dateFormat, prefixResId = datePrefixResId)
+        binding.Date.displayFormattedTimestamp(date, dateFormat, datePrefixResId)
+
         setColor(baseNote.color)
         setImages(baseNote.images, imageRoot)
         setFiles(baseNote.files)
@@ -225,7 +228,7 @@ class BaseNoteVH(
     private fun setFiles(files: List<FileAttachment>) {
         binding.apply {
             if (files.isNotEmpty()) {
-                FileView.visibility = View.VISIBLE
+                FileViewLayout.visibility = View.VISIBLE
                 FileView.text = files[0].originalName
                 if (files.size > 1) {
                     FileViewMore.apply {
@@ -236,8 +239,7 @@ class BaseNoteVH(
                     FileViewMore.visibility = View.GONE
                 }
             } else {
-                FileView.visibility = View.GONE
-                FileViewMore.visibility = View.GONE
+                FileViewLayout.visibility = View.GONE
             }
         }
     }

--- a/app/src/main/java/com/philkes/notallyx/presentation/view/main/BaseNoteVH.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/view/main/BaseNoteVH.kt
@@ -24,6 +24,7 @@ import com.philkes.notallyx.data.model.ListItem
 import com.philkes.notallyx.data.model.SpanRepresentation
 import com.philkes.notallyx.data.model.Type
 import com.philkes.notallyx.databinding.RecyclerBaseNoteBinding
+import com.philkes.notallyx.presentation.view.misc.NotesSorting.autoSortByModifiedDate
 import com.philkes.notallyx.presentation.view.misc.TextSize
 import com.philkes.notallyx.presentation.view.note.listitem.ListItemListener
 import com.philkes.notallyx.utils.Operations
@@ -73,15 +74,19 @@ class BaseNoteVH(
         binding.root.isChecked = checked
     }
 
-    fun bind(baseNote: BaseNote, imageRoot: File?, checked: Boolean) {
+    fun bind(baseNote: BaseNote, imageRoot: File?, checked: Boolean, sortingKey: String) {
         updateCheck(checked)
 
         when (baseNote.type) {
             Type.NOTE -> bindNote(baseNote.body, baseNote.spans)
             Type.LIST -> bindList(baseNote.items)
         }
-
-        binding.Date.displayFormattedTimestamp(baseNote.timestamp, dateFormat)
+        val (date, datePrefixResId) =
+            when (sortingKey) {
+                autoSortByModifiedDate -> Pair(baseNote.modifiedTimestamp, R.string.modified_date)
+                else -> Pair(baseNote.timestamp, R.string.creation_date)
+            }
+        binding.Date.displayFormattedTimestamp(date, dateFormat, prefixResId = datePrefixResId)
         setColor(baseNote.color)
         setImages(baseNote.images, imageRoot)
         setFiles(baseNote.files)

--- a/app/src/main/java/com/philkes/notallyx/presentation/view/misc/ListInfo.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/view/misc/ListInfo.kt
@@ -63,7 +63,7 @@ object DateFormat : ListInfo {
     const val relative = "relative"
     const val absolute = "absolute"
 
-    override val title = R.string.creation_date_format
+    override val title = R.string.date_format
     override val key = "dateFormat"
     override val defaultValue = relative
 

--- a/app/src/main/java/com/philkes/notallyx/presentation/widget/WidgetFactory.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/widget/WidgetFactory.kt
@@ -15,7 +15,6 @@ import com.philkes.notallyx.data.model.BaseNote
 import com.philkes.notallyx.data.model.Type
 import com.philkes.notallyx.presentation.view.misc.TextSize
 import com.philkes.notallyx.presentation.widget.WidgetProvider.Companion.getSelectNoteIntent
-import com.philkes.notallyx.utils.displayFormattedTimestamp
 
 class WidgetFactory(private val app: Application, private val id: Long, private val widgetId: Int) :
     RemoteViewsService.RemoteViewsFactory {
@@ -71,9 +70,6 @@ class WidgetFactory(private val app: Application, private val id: Long, private 
 
             val bodyTextSize = TextSize.getDisplayBodySize(preferences.textSize.value)
 
-            setTextViewTextSize(R.id.Date, TypedValue.COMPLEX_UNIT_SP, bodyTextSize)
-            displayFormattedTimestamp(R.id.Date, note.timestamp, preferences.dateFormat.value)
-
             setTextViewTextSize(R.id.Note, TypedValue.COMPLEX_UNIT_SP, bodyTextSize)
             if (note.body.isNotEmpty()) {
                 setTextViewText(R.id.Note, note.body)
@@ -95,11 +91,6 @@ class WidgetFactory(private val app: Application, private val id: Long, private 
                 TextSize.getDisplayTitleSize(preferences.textSize.value),
             )
             setTextViewText(R.id.Title, list.title)
-
-            val bodyTextSize = TextSize.getDisplayBodySize(preferences.textSize.value)
-
-            setTextViewTextSize(R.id.Date, TypedValue.COMPLEX_UNIT_SP, bodyTextSize)
-            displayFormattedTimestamp(R.id.Date, list.timestamp, preferences.dateFormat.value)
 
             val intent = Intent(WidgetProvider.ACTION_OPEN_LIST)
             setOnClickFillInIntent(R.id.LinearLayout, intent)

--- a/app/src/main/java/com/philkes/notallyx/utils/Extensions.kt
+++ b/app/src/main/java/com/philkes/notallyx/utils/Extensions.kt
@@ -29,7 +29,6 @@ import android.view.inputmethod.InputMethodManager
 import android.widget.EditText
 import android.widget.RadioButton
 import android.widget.RadioGroup
-import android.widget.RemoteViews
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity.INPUT_METHOD_SERVICE
 import androidx.appcompat.app.AppCompatActivity.KEYGUARD_SERVICE
@@ -183,18 +182,16 @@ fun Menu.add(
     return menuItem
 }
 
-fun TextView.displayFormattedTimestamp(timestamp: Long, dateFormat: String) {
+fun TextView.displayFormattedTimestamp(
+    timestamp: Long,
+    dateFormat: String,
+    prefixResId: Int? = null,
+) {
     if (dateFormat != DateFormat.none) {
         visibility = View.VISIBLE
-        text = formatTimestamp(timestamp, dateFormat)
+        text =
+            "${prefixResId?.let { getString(it) } ?: ""} ${formatTimestamp(timestamp, dateFormat)}"
     } else visibility = View.GONE
-}
-
-fun RemoteViews.displayFormattedTimestamp(id: Int, timestamp: Long, dateFormat: String) {
-    if (dateFormat != DateFormat.none) {
-        setViewVisibility(id, View.VISIBLE)
-        setTextViewText(id, formatTimestamp(timestamp, dateFormat))
-    } else setViewVisibility(id, View.GONE)
 }
 
 val Int.dp: Int
@@ -264,8 +261,8 @@ fun EditText.createTextWatcherWithHistory(
 
 fun Editable.clone(): Editable = Editable.Factory.getInstance().newEditable(this)
 
-fun View.getQuantityString(id: Int, quantity: Int): String {
-    return context.resources.getQuantityString(id, quantity, quantity)
+fun View.getString(id: Int, vararg formatArgs: String): String {
+    return context.resources.getString(id, *formatArgs)
 }
 
 fun View.getQuantityString(id: Int, quantity: Int, vararg formatArgs: Any): String {

--- a/app/src/main/java/com/philkes/notallyx/utils/Extensions.kt
+++ b/app/src/main/java/com/philkes/notallyx/utils/Extensions.kt
@@ -183,11 +183,11 @@ fun Menu.add(
 }
 
 fun TextView.displayFormattedTimestamp(
-    timestamp: Long,
+    timestamp: Long?,
     dateFormat: String,
     prefixResId: Int? = null,
 ) {
-    if (dateFormat != DateFormat.none) {
+    if (dateFormat != DateFormat.none && timestamp != null) {
         visibility = View.VISIBLE
         text =
             "${prefixResId?.let { getString(it) } ?: ""} ${formatTimestamp(timestamp, dateFormat)}"

--- a/app/src/main/java/com/philkes/notallyx/utils/backup/Import.kt
+++ b/app/src/main/java/com/philkes/notallyx/utils/backup/Import.kt
@@ -37,8 +37,8 @@ import net.lingala.zip4j.exception.ZipException
 object Import {
 
     /**
-     * We only import the images/files referenced in notes. e.g If someone has added garbage to the ZIP
-     * file, like a 100 MB image, ignore it.
+     * We only import the images/files referenced in notes. e.g If someone has added garbage to the
+     * ZIP file, like a 100 MB image, ignore it.
      */
     suspend fun importZip(
         app: Application,

--- a/app/src/main/res/layout/activity_edit.xml
+++ b/app/src/main/res/layout/activity_edit.xml
@@ -77,7 +77,7 @@
                 android:textAppearance="?attr/textAppearanceHeadline6" />
 
             <TextView
-                android:id="@+id/DateCreated"
+                android:id="@+id/Date"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:paddingStart="24dp"

--- a/app/src/main/res/layout/recycler_base_note.xml
+++ b/app/src/main/res/layout/recycler_base_note.xml
@@ -65,7 +65,7 @@
         <Space
             android:id="@+id/Space"
             android:layout_width="match_parent"
-            android:layout_height="16dp"
+            android:layout_height="14dp"
             app:layout_constraintTop_toBottomOf="@id/Message" />
 
         <TextView
@@ -76,6 +76,7 @@
             android:fontFamily="sans-serif-medium"
             android:paddingStart="16dp"
             android:paddingEnd="16dp"
+            android:paddingBottom="8dp"
             android:textAppearance="?attr/textAppearanceBody1"
             android:textColor="?attr/colorOnSurface"
             app:layout_constraintTop_toBottomOf="@id/Space" />
@@ -87,7 +88,7 @@
             android:layout_height="wrap_content"
             android:paddingStart="16dp"
             android:paddingEnd="16dp"
-            android:paddingBottom="2dp"
+            android:paddingBottom="6dp"
             app:layout_constraintTop_toBottomOf="@id/Title" />
 
         <LinearLayout
@@ -95,6 +96,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="horizontal"
+            android:paddingTop="0dp"
             android:paddingBottom="4dp"
             app:layout_constraintTop_toBottomOf="@id/Date"
             >

--- a/app/src/main/res/layout/widget_list_header.xml
+++ b/app/src/main/res/layout/widget_list_header.xml
@@ -35,14 +35,4 @@
 
     </LinearLayout>
 
-
-
-    <TextView
-        android:id="@+id/Date"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:paddingBottom="16dp"
-        android:textAppearance="?attr/textAppearanceBody2"
-        android:textColor="?android:textColorSecondary" />
-
 </LinearLayout>

--- a/app/src/main/res/layout/widget_note.xml
+++ b/app/src/main/res/layout/widget_note.xml
@@ -34,14 +34,6 @@
     </LinearLayout>
 
     <TextView
-        android:id="@+id/Date"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:paddingBottom="16dp"
-        android:textAppearance="@style/TextAppearance.MaterialComponents.Body2"
-        android:textColor="?android:textColorSecondary" />
-
-    <TextView
         android:id="@+id/Note"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -89,7 +89,7 @@
     <string name="light">Světlé</string>
     <string name="follow_system">Podle systému</string>
 
-    <string name="creation_date_format">Formát data</string>
+    <string name="date_format">Formát data</string>
     <string name="none">Žádné</string>
 
     <string name="text_size">Velikost písma</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -91,7 +91,7 @@
     <string name="light">Hell</string>
     <string name="follow_system">Systemeinstellung folgen</string>
 
-    <string name="creation_date_format">Datumsformat</string>
+    <string name="date_format">Datumsformat</string>
     <string name="none">Keines</string>
 
     <string name="text_size">Textgröße</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -79,7 +79,7 @@
     <string name="light">Φωτεινό</string>
     <string name="follow_system">Ακολούθηση συστήματος</string>
 
-    <string name="creation_date_format">Μορφή ημερομηνίας</string>
+    <string name="date_format">Μορφή ημερομηνίας</string>
     <string name="none">Καμία</string>
 
     <string name="content_density">Πυκνότητα περιεχομένου</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -79,7 +79,7 @@
     <string name="list">Lista</string>
     <string name="grid">Cuadrícula</string>
 
-    <string name="creation_date_format">Formato de fecha</string>
+    <string name="date_format">Formato de fecha</string>
     <string name="none">Ninguno</string>
 
     <string name="text_size">Tamaño de texto</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -89,7 +89,7 @@
     <string name="light">Lumineux</string>
     <string name="follow_system">En fonction du système</string>
 
-    <string name="creation_date_format">Format de la date</string>
+    <string name="date_format">Format de la date</string>
     <string name="none">Aucun</string>
 
     <string name="text_size">Taille du texte</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -83,7 +83,7 @@
     <string name="light">Terang</string>
     <string name="follow_system">Ikuti sistem</string>
 
-    <string name="creation_date_format">Format tanggal</string>
+    <string name="date_format">Format tanggal</string>
     <string name="none">Tidak ada</string>
 
     <string name="content_density">Kerapatan konten</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -83,7 +83,7 @@
     <string name="light">Chiaro</string>
     <string name="follow_system">Tema di Sistema</string>
 
-    <string name="creation_date_format">Formato data</string>
+    <string name="date_format">Formato data</string>
     <string name="none">Nessuno</string>
 
     <string name="content_density">Densità del contenuto</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -80,7 +80,7 @@
     <string name="light">ライト</string>
     <string name="follow_system">システムのテーマを使用</string>
 
-    <string name="creation_date_format">日付の表示</string>
+    <string name="date_format">日付の表示</string>
     <string name="none">表示しない</string>
 
     <string name="content_density">プレビュー</string>

--- a/app/src/main/res/values-my/strings.xml
+++ b/app/src/main/res/values-my/strings.xml
@@ -89,7 +89,7 @@
     <string name="light">အလင်း</string>
     <string name="follow_system">ဖုန်းအတိုင်း</string>
 
-    <string name="creation_date_format">နေ့ရက်ပုံစံ</string>
+    <string name="date_format">နေ့ရက်ပုံစံ</string>
     <string name="none">ဘာမှမရှိ</string>
 
     <string name="text_size">စာလလုံးအရွယ်အစား</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -88,7 +88,7 @@
     <string name="light">Lyst</string>
     <string name="follow_system">Følg systemet</string>
 
-    <string name="creation_date_format">Datoformat</string>
+    <string name="date_format">Datoformat</string>
     <string name="none">Ikke vis</string>
 
     <string name="text_size">Skriftstørrelse</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -123,7 +123,7 @@
     <string name="light">Licht</string>
     <string name="follow_system">Volg systeeminstellingen</string>
 
-    <string name="creation_date_format">Datumformaat</string>
+    <string name="date_format">Datumformaat</string>
     <string name="none">Geen</string>
 
     <string name="text_size">Tekstgrootte</string>
@@ -136,8 +136,8 @@
     <string name="auto_sort_by_checked">Automatisch sorteren op geselecteerde items</string>
 
     <string name="notes_sorted_by">Notities gesorteerd op</string>
-    <string name="creation_date">Gemaakt op</string>
-    <string name="modified_date">Laatst gewijzigd op</string>
+    <string name="creation_date">Gemaakt</string>
+    <string name="modified_date">Gewijzigd</string>
     <string name="ascending">Oplopend</string>
     <string name="descending">Aflopend</string>
     <string name="sort_direction">Sorteer volgorde</string>

--- a/app/src/main/res/values-nn/strings.xml
+++ b/app/src/main/res/values-nn/strings.xml
@@ -88,7 +88,7 @@
     <string name="light">Lyst</string>
     <string name="follow_system">Følg systemet</string>
 
-    <string name="creation_date_format">Datoformat</string>
+    <string name="date_format">Datoformat</string>
     <string name="none">Ikkje vis</string>
 
     <string name="text_size">Skriftstorleik</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -89,7 +89,7 @@
     <string name="light">Jasny</string>
     <string name="follow_system">Systemowy</string>
 
-    <string name="creation_date_format">Format daty</string>
+    <string name="date_format">Format daty</string>
     <string name="none">Brak</string>
 
     <string name="text_size">Rozmiar tekstu</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -78,7 +78,7 @@
     <string name="light">Claro</string>
     <string name="follow_system">Seguir o sistema</string>
 
-    <string name="creation_date_format">Formato da data</string>
+    <string name="date_format">Formato da data</string>
     <string name="none">Nenhum</string>
 
     <string name="content_density">Densidade do conteúdo</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -90,7 +90,7 @@
     <string name="light">Luminos</string>
     <string name="follow_system">Urmează sistemul</string>
 
-    <string name="creation_date_format">Formatul datei</string>
+    <string name="date_format">Formatul datei</string>
     <string name="none">Nici unul</string>
 
     <string name="text_size">Mărimea textului</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -81,7 +81,7 @@
     <string name="light">Светлая</string>
     <string name="follow_system">Как в системе</string>
 
-    <string name="creation_date_format">Формат даты</string>
+    <string name="date_format">Формат даты</string>
     <string name="none">Отсутствует</string>
 
     <string name="content_density">Плотность контента</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -90,7 +90,7 @@
     <string name="light">Svetlo</string>
     <string name="follow_system">Privzeto v sistemu</string>
 
-    <string name="creation_date_format">Zapis datuma</string>
+    <string name="date_format">Zapis datuma</string>
     <string name="none">Brez</string>
 
     <string name="text_size">Velikost pisave</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -80,7 +80,7 @@
     <string name="light">Açık</string>
     <string name="follow_system">Sistem varsayılanı</string>
 
-    <string name="creation_date_format">Zaman biçimi</string>
+    <string name="date_format">Zaman biçimi</string>
     <string name="none">Hiçbiri</string>
 
     <string name="content_density">İçerik yoğunluğu</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -89,7 +89,7 @@
     <string name="light">Sáng</string>
     <string name="follow_system">Mặc định hệ thống</string>
 
-    <string name="creation_date_format">Định dạng ngày tháng</string>
+    <string name="date_format">Định dạng ngày tháng</string>
     <string name="none">Không</string>
 
     <string name="text_size">Cỡ chữ</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -86,7 +86,7 @@
     <string name="light">浅</string>
     <string name="follow_system">系统主题</string>
 
-    <string name="creation_date_format">日期格式</string>
+    <string name="date_format">日期格式</string>
     <string name="none">无</string>
 
     <string name="text_size">文本大小</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -129,7 +129,7 @@
     <string name="light">Light</string>
     <string name="follow_system">Follow system</string>
 
-    <string name="creation_date_format">Creation Date format</string>
+    <string name="date_format">Date format</string>
     <string name="none">None</string>
 
     <string name="text_size">Text size</string>
@@ -142,8 +142,8 @@
     <string name="auto_sort_by_checked">Autosort by checked items</string>
 
     <string name="notes_sorted_by">Notes sorted by</string>
-    <string name="creation_date">Created At</string>
-    <string name="modified_date">Last Modified At</string>
+    <string name="creation_date">Created</string>
+    <string name="modified_date">Modified</string>
     <string name="ascending">Ascending</string>
     <string name="descending">Descending</string>
     <string name="sort_direction">Sort Direction</string>


### PR DESCRIPTION
Closes #60 and Closes #59

* The displayed date corresponds to the `Notes sorted by` preference, e.g. when sorted by created date:
![image](https://github.com/user-attachments/assets/f92d689b-1d96-4891-867d-cb48bd5e0302)

* If `Notes sorted by` is set to title or the `Date Format` preference is set to `None`, then no date is displayed:
![image](https://github.com/user-attachments/assets/200b9be5-5c9a-4d36-8f94-1c5797ab0e19)


* No date is displayed in the Widget anymore, since it just takes up space:
![image](https://github.com/user-attachments/assets/0b93a2c2-ca18-42ea-a1f3-300ae2c005ee)

* When selecting a note for the Widget the notes are also sorted by the `Notes sorted by` preference
