### PR TITLE
Migrate startActivityForResult and other minor deprecations

### DIFF
--- a/app/src/main/java/com/philkes/notallyx/presentation/UiExtensions.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/UiExtensions.kt
@@ -7,6 +7,7 @@ import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.ContentResolver
 import android.content.Context
+import android.content.Intent
 import android.content.pm.PackageManager
 import android.graphics.Typeface
 import android.hardware.biometrics.BiometricManager
@@ -14,6 +15,8 @@ import android.hardware.biometrics.BiometricManager.Authenticators.BIOMETRIC_STR
 import android.hardware.biometrics.BiometricManager.Authenticators.DEVICE_CREDENTIAL
 import android.net.Uri
 import android.os.Build
+import android.os.Bundle
+import android.os.Parcelable
 import android.provider.OpenableColumns
 import android.text.Editable
 import android.text.InputType
@@ -485,4 +488,42 @@ fun MaterialAlertDialogBuilder.showAndFocus(view: View): AlertDialog {
 
 fun Context.getQuantityString(id: Int, quantity: Int, vararg formatArgs: Any): String {
     return resources.getQuantityString(id, quantity, quantity, *formatArgs)
+}
+
+fun <T : Parcelable> Bundle?.getParcelableCompat(key: String, clazz: Class<T>): T? {
+    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        this?.getParcelable(key, clazz)
+    } else {
+        this?.getParcelable(key)
+    }
+}
+
+fun <T : Parcelable> Bundle?.getParcelableArrayListCompat(
+    key: String,
+    clazz: Class<T>,
+): ArrayList<T>? {
+    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        this?.getParcelableArrayList(key, clazz)
+    } else {
+        this?.getParcelableArrayList(key)
+    }
+}
+
+fun <T : Parcelable> Intent?.getParcelableArrayListExtraCompat(
+    key: String,
+    clazz: Class<T>,
+): ArrayList<T>? {
+    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        this?.getParcelableArrayListExtra(key, clazz)
+    } else {
+        this?.getParcelableArrayListExtra(key)
+    }
+}
+
+fun <T : Parcelable> Intent?.getParcelableExtraCompat(key: String, clazz: Class<T>): T? {
+    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        this?.getParcelableExtra(key, clazz)
+    } else {
+        this?.getParcelableExtra(key)
+    }
 }

--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/main/fragment/SearchFragment.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/main/fragment/SearchFragment.kt
@@ -23,8 +23,8 @@ class SearchFragment : NotallyFragment() {
             }
 
         binding?.ChipGroup?.apply {
-            setOnCheckedChangeListener { _, checkedId ->
-                when (checkedId) {
+            setOnCheckedStateChangeListener { _, checkedId ->
+                when (checkedId.first()) {
                     R.id.Notes -> model.folder = Folder.NOTES
                     R.id.Deleted -> model.folder = Folder.DELETED
                     R.id.Archived -> model.folder = Folder.ARCHIVED

--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/note/RecordAudioActivity.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/note/RecordAudioActivity.kt
@@ -5,7 +5,9 @@ import android.content.Intent
 import android.content.ServiceConnection
 import android.os.Bundle
 import android.os.IBinder
+import androidx.activity.OnBackPressedCallback
 import androidx.annotation.RequiresApi
+import androidx.lifecycle.Observer
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.philkes.notallyx.R
 import com.philkes.notallyx.databinding.ActivityRecordAudioBinding
@@ -20,6 +22,8 @@ class RecordAudioActivity : LockedActivity<ActivityRecordAudioBinding>() {
 
     private var service: AudioRecordService? = null
     private lateinit var connection: ServiceConnection
+    private lateinit var serviceStatusObserver: Observer<Status>
+    private lateinit var cancelRecordCallback: OnBackPressedCallback
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -33,7 +37,7 @@ class RecordAudioActivity : LockedActivity<ActivityRecordAudioBinding>() {
             object : ServiceConnection {
                 override fun onServiceConnected(name: ComponentName, binder: IBinder) {
                     service = (binder as LocalBinder<AudioRecordService>).getService()
-                    updateUI(binding, requireNotNull(service))
+                    service?.status?.observe(this@RecordAudioActivity, serviceStatusObserver)
                 }
 
                 override fun onServiceDisconnected(name: ComponentName?) {}
@@ -44,12 +48,11 @@ class RecordAudioActivity : LockedActivity<ActivityRecordAudioBinding>() {
         binding.Main.setOnClickListener {
             val service = this.service
             if (service != null) {
-                when (service.status) {
+                when (service.status.value) {
                     Status.PAUSED -> service.resume()
                     Status.READY -> service.start()
                     Status.RECORDING -> service.pause()
                 }
-                updateUI(binding, service)
             }
         }
 
@@ -60,32 +63,36 @@ class RecordAudioActivity : LockedActivity<ActivityRecordAudioBinding>() {
             }
         }
 
-        binding.Toolbar.setNavigationOnClickListener { onBackPressed() }
+        binding.Toolbar.setNavigationOnClickListener { onBackPressedDispatcher.onBackPressed() }
+
+        cancelRecordCallback =
+            object : OnBackPressedCallback(true) {
+                override fun handleOnBackPressed() {
+                    MaterialAlertDialogBuilder(this@RecordAudioActivity)
+                        .setMessage(R.string.save_recording)
+                        .setPositiveButton(R.string.save) { _, _ -> stopRecording(service!!) }
+                        .setNegativeButton(R.string.discard) { _, _ -> discard(service!!) }
+                        .show()
+                }
+            }
+        onBackPressedDispatcher.addCallback(cancelRecordCallback)
+        serviceStatusObserver = Observer { status ->
+            updateUI(binding, service!!)
+            cancelRecordCallback.isEnabled = status != Status.READY
+        }
     }
 
     override fun onDestroy() {
         super.onDestroy()
-        if (service != null) {
+        service?.let {
             unbindService(connection)
+            it.status.removeObserver(serviceStatusObserver)
             service = null
         }
         if (isFinishing) {
             val intent = Intent(this, AudioRecordService::class.java)
             stopService(intent)
         }
-    }
-
-    override fun onBackPressed() {
-        val service = this.service
-        if (service != null) {
-            if (service.status != Status.READY) {
-                MaterialAlertDialogBuilder(this)
-                    .setMessage(R.string.save_recording)
-                    .setPositiveButton(R.string.save) { _, _ -> stopRecording(service) }
-                    .setNegativeButton(R.string.discard) { _, _ -> discard(service) }
-                    .show()
-            } else super.onBackPressed()
-        } else super.onBackPressed()
     }
 
     private fun discard(service: AudioRecordService) {
@@ -102,7 +109,7 @@ class RecordAudioActivity : LockedActivity<ActivityRecordAudioBinding>() {
 
     private fun updateUI(binding: ActivityRecordAudioBinding, service: AudioRecordService) {
         binding.Timer.base = service.getBase()
-        when (service.status) {
+        when (service.status.value) {
             Status.READY -> {
                 binding.Stop.isEnabled = false
                 binding.Main.setText(R.string.start)

--- a/app/src/main/java/com/philkes/notallyx/presentation/view/main/ColorAdapter.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/view/main/ColorAdapter.kt
@@ -9,7 +9,7 @@ import com.philkes.notallyx.presentation.view.note.listitem.ListItemListener
 
 class ColorAdapter(private val listener: ListItemListener) : RecyclerView.Adapter<ColorVH>() {
 
-    private val colors = Color.values()
+    private val colors = Color.entries.toTypedArray()
 
     override fun getItemCount() = colors.size
 

--- a/app/src/main/java/com/philkes/notallyx/presentation/view/misc/EditTextWithHistory.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/view/misc/EditTextWithHistory.kt
@@ -43,12 +43,13 @@ class EditTextWithHistory(context: Context, attrs: AttributeSet) :
                 { text, start, count ->
                     val changedText = text.substring(start, start + count)
                     if (changedText.isWebUrl() || changedText.isNoteUrl()) {
-                        this.text?.setSpan(
-                            URLSpan(changedText),
-                            start,
-                            start + count,
-                            Spanned.SPAN_EXCLUSIVE_EXCLUSIVE,
-                        )
+                        super.getText()
+                            ?.setSpan(
+                                URLSpan(changedText),
+                                start,
+                                start + count,
+                                Spanned.SPAN_EXCLUSIVE_EXCLUSIVE,
+                            )
                     }
                 },
             ) { text: Editable ->

--- a/app/src/main/java/com/philkes/notallyx/presentation/view/note/listitem/ListItemDragCallback.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/view/note/listitem/ListItemDragCallback.kt
@@ -105,7 +105,7 @@ class ListItemDragCallback(private val elevation: Float, private val listManager
         val item = listManager.getItem(viewHolder.adapterPosition)
         if (!item.isChild) {
             childViewHolders =
-                item.children.mapIndexedNotNull { index, listItem ->
+                item.children.mapIndexedNotNull { index, _ ->
                     recyclerView.findViewHolderForAdapterPosition(
                         viewHolder.adapterPosition + index + 1
                     )

--- a/app/src/main/java/com/philkes/notallyx/presentation/view/note/listitem/ListManager.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/view/note/listitem/ListManager.kt
@@ -185,7 +185,7 @@ class ListManager(
     ) {
         if (updateIsChild) {
             if (newPosition.isBeforeChildItemOfOtherParent) {
-                items.setIsChild(newPosition, true, true)
+                items.setIsChild(newPosition, isChild = true, forceOnChildren = true)
             } else if (newPosition == 0) {
                 items.setIsChild(newPosition, false)
             }

--- a/app/src/main/java/com/philkes/notallyx/presentation/view/note/listitem/sorting/ListItemSortedList.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/view/note/listitem/sorting/ListItemSortedList.kt
@@ -155,9 +155,9 @@ class ListItemSortedList(private val callback: Callback<ListItem>) :
     }
 
     private fun updateChildInParent(position: Int, item: ListItem) {
-        var childIndex: Int? = null
-        var parentInfo = findParent(item)
-        var parent: ListItem? = null
+        val childIndex: Int?
+        val parentInfo = findParent(item)
+        val parent: ListItem?
         if (parentInfo == null) {
             val parentPosition = findLastIsNotChild(position - 1)!!
             childIndex = position - parentPosition - 1

--- a/app/src/main/java/com/philkes/notallyx/presentation/view/note/listitem/sorting/ListItemSortedListExtensions.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/view/note/listitem/sorting/ListItemSortedListExtensions.kt
@@ -217,7 +217,7 @@ private fun ListItemSortedList.updatePositions(
             idsOfChildren.addAll(
                 updatedItem.children
                     .reversed() // start recalculations from the lowest child upwards
-                    .map { it.id }
+                    .map { item -> item.id }
             )
         }
         this.updateItemAt(newPosition, updatedItem)

--- a/app/src/main/java/com/philkes/notallyx/presentation/widget/WidgetProvider.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/widget/WidgetProvider.kt
@@ -7,6 +7,7 @@ import android.appwidget.AppWidgetProvider
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
+import android.os.Build
 import android.widget.RemoteViews
 import com.philkes.notallyx.Preferences
 import com.philkes.notallyx.R
@@ -49,7 +50,10 @@ class WidgetProvider : AppWidgetProvider() {
     private fun checkChanged(intent: Intent, context: Context) {
         val noteId = intent.getLongExtra(Constants.SelectedBaseNote, 0)
         val position = intent.getIntExtra(EXTRA_POSITION, 0)
-        val checked = intent.getBooleanExtra(RemoteViews.EXTRA_CHECKED, false)
+        val checked =
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                intent.getBooleanExtra(RemoteViews.EXTRA_CHECKED, false)
+            } else false
         val database = NotallyDatabase.getDatabase(context.applicationContext as Application).value
         val pendingResult = goAsync()
         GlobalScope.launch {

--- a/app/src/main/java/com/philkes/notallyx/utils/audio/AudioRecordService.kt
+++ b/app/src/main/java/com/philkes/notallyx/utils/audio/AudioRecordService.kt
@@ -6,6 +6,7 @@ import android.media.MediaRecorder
 import android.os.Build
 import android.os.SystemClock
 import androidx.annotation.RequiresApi
+import com.philkes.notallyx.presentation.view.misc.BetterLiveData
 import com.philkes.notallyx.utils.IO.getTempAudioFile
 import com.philkes.notallyx.utils.audio.Status.PAUSED
 import com.philkes.notallyx.utils.audio.Status.READY
@@ -14,7 +15,7 @@ import com.philkes.notallyx.utils.audio.Status.RECORDING
 @RequiresApi(24)
 class AudioRecordService : Service() {
 
-    var status = READY
+    var status = BetterLiveData(READY)
     private var lastStart = 0L
     private var audioDuration = 0L
 
@@ -45,19 +46,19 @@ class AudioRecordService : Service() {
 
     fun start() {
         recorder.start()
-        status = RECORDING
+        status.value = RECORDING
         lastStart = SystemClock.elapsedRealtime()
     }
 
     fun resume() {
         recorder.resume()
-        status = RECORDING
+        status.value = RECORDING
         lastStart = SystemClock.elapsedRealtime()
     }
 
     fun pause() {
         recorder.pause()
-        status = PAUSED
+        status.value = PAUSED
         audioDuration += SystemClock.elapsedRealtime() - lastStart
         lastStart = 0L
     }

--- a/app/src/main/java/com/philkes/notallyx/utils/security/LockUtils.kt
+++ b/app/src/main/java/com/philkes/notallyx/utils/security/LockUtils.kt
@@ -10,6 +10,7 @@ import android.hardware.fingerprint.FingerprintManager
 import android.os.Build
 import android.os.CancellationSignal
 import android.widget.Toast
+import androidx.activity.result.ActivityResultLauncher
 import androidx.fragment.app.Fragment
 import com.philkes.notallyx.R
 import javax.crypto.Cipher
@@ -17,7 +18,7 @@ import javax.crypto.Cipher
 fun Activity.showBiometricOrPinPrompt(
     isForDecrypt: Boolean,
     cipherIv: ByteArray? = null,
-    requestCode: Int,
+    activityResultLauncher: ActivityResultLauncher<Intent>,
     titleResId: Int,
     descriptionResId: Int? = null,
     onSuccess: (cipher: Cipher) -> Unit,
@@ -26,7 +27,7 @@ fun Activity.showBiometricOrPinPrompt(
     showBiometricOrPinPrompt(
         isForDecrypt,
         this,
-        requestCode,
+        activityResultLauncher,
         titleResId,
         descriptionResId,
         cipherIv,
@@ -38,7 +39,7 @@ fun Activity.showBiometricOrPinPrompt(
 
 fun Fragment.showBiometricOrPinPrompt(
     isForDecrypt: Boolean,
-    requestCode: Int,
+    activityResultLauncher: ActivityResultLauncher<Intent>,
     titleResId: Int,
     descriptionResId: Int,
     cipherIv: ByteArray? = null,
@@ -48,7 +49,7 @@ fun Fragment.showBiometricOrPinPrompt(
     showBiometricOrPinPrompt(
         isForDecrypt,
         requireContext(),
-        requestCode,
+        activityResultLauncher,
         titleResId,
         descriptionResId,
         cipherIv,
@@ -61,7 +62,7 @@ fun Fragment.showBiometricOrPinPrompt(
 private fun showBiometricOrPinPrompt(
     isForDecrypt: Boolean,
     context: Context,
-    requestCode: Int,
+    activityResultLauncher: ActivityResultLauncher<Intent>,
     titleResId: Int,
     descriptionResId: Int? = null,
     cipherIv: ByteArray? = null,
@@ -159,7 +160,7 @@ private fun showBiometricOrPinPrompt(
             } else {
                 promptPinAuthentication(
                     context,
-                    requestCode,
+                    activityResultLauncher,
                     titleResId,
                     startActivityForResult,
                     onFailure,
@@ -171,7 +172,7 @@ private fun showBiometricOrPinPrompt(
             // API 21-22: No biometric support, fallback to PIN/Password
             promptPinAuthentication(
                 context,
-                requestCode,
+                activityResultLauncher,
                 titleResId,
                 startActivityForResult,
                 onFailure,
@@ -190,7 +191,7 @@ private fun getCancellationSignal(context: Context): CancellationSignal {
 
 private fun promptPinAuthentication(
     context: Context,
-    requestCode: Int,
+    activityResultLauncher: ActivityResultLauncher<Intent>,
     titleResId: Int,
     startActivityForResult: (intent: Intent, requestCode: Int) -> Unit,
     onFailure: () -> Unit,
@@ -205,7 +206,7 @@ private fun promptPinAuthentication(
                     null,
                 )
             if (intent != null) {
-                startActivityForResult(intent, requestCode)
+                activityResultLauncher.launch(intent)
             } else {
                 onFailure.invoke()
             }
@@ -221,7 +222,7 @@ private fun promptPinAuthentication(
                     null,
                 )
             if (intent != null) {
-                startActivityForResult(intent, requestCode)
+                activityResultLauncher.launch(intent)
             } else {
                 onFailure.invoke()
             }


### PR DESCRIPTION
See #82 

* Replaces deprecated `startActivityForResult` with [ActivityResultLauncher](https://developer.android.com/reference/androidx/activity/result/ActivityResultLauncher)
* Adds some minor version checks for deprecated usages