### PR TITLE
Theme adjusts Android navbar color

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -6,8 +6,6 @@
 
         <item name="colorPrimaryDark">?attr/colorSurface</item>
 
-        <item name="android:navigationBarColor">@color/Black</item>
-
         <item name="windowActionModeOverlay">true</item>
 
         <item name="textAppearanceButton">@style/TextAppearance.Subtitle2</item>


### PR DESCRIPTION
Closes #95 

* The Android navbar color was statically set to black, now it adapts to the current Theme:

<div style="display: flex; justify-content: space-between; width: 100%;">
<img src="https://github.com/user-attachments/assets/a2a22865-9d21-4574-b7c6-6d55916fb425" width="250"/>
<img src="https://github.com/user-attachments/assets/b4944a3d-9b86-416f-9110-4a0e80a3ed17" width="250" />
</div> 