### PR TITLE
Dont observe BiometricLock in zip auto-backup

### DIFF
--- a/app/src/main/java/com/philkes/notallyx/presentation/widget/WidgetProvider.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/widget/WidgetProvider.kt
@@ -55,7 +55,12 @@ class WidgetProvider : AppWidgetProvider() {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
                 intent.getBooleanExtra(RemoteViews.EXTRA_CHECKED, false)
             } else false
-        val database = NotallyDatabase.getDatabase(context.applicationContext as Application).value
+        val database =
+            NotallyDatabase.getDatabase(
+                    context.applicationContext as Application,
+                    observeBiometricLock = false,
+                )
+                .value
         val pendingResult = goAsync()
         GlobalScope.launch {
             withContext(Dispatchers.IO) {

--- a/app/src/main/java/com/philkes/notallyx/utils/Operations.kt
+++ b/app/src/main/java/com/philkes/notallyx/utils/Operations.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.res.ColorStateList
 import android.os.Build
+import android.util.Log
 import android.util.TypedValue
 import android.view.LayoutInflater
 import android.view.View
@@ -30,6 +31,8 @@ import java.text.DateFormat
 
 object Operations {
 
+    private const val TAG = "Operations"
+
     const val extraCharSequence = "com.philkes.notallyx.extra.charSequence"
 
     fun getLastExceptionLog(app: Application): String? {
@@ -42,8 +45,9 @@ object Operations {
     }
 
     fun log(app: Application, throwable: Throwable) {
+        Log.e(TAG, "Exception occurred", throwable)
         val file = getLog(app)
-        val output = FileOutputStream(file, true)
+        val output = FileOutputStream(file, !file.exists() || !file.isLargerThan(2048))
         val writer = PrintWriter(OutputStreamWriter(output, Charsets.UTF_8))
 
         val formatter = DateFormat.getDateTimeInstance()
@@ -141,5 +145,9 @@ object Operations {
         drawable.strokeColor = ContextCompat.getColorStateList(context, R.color.chip_stroke)
 
         return drawable
+    }
+
+    private fun File.isLargerThan(kilobytes: Long): Boolean {
+        return (length() / 1024) > kilobytes
     }
 }

--- a/app/src/main/java/com/philkes/notallyx/utils/backup/AutoBackupWorker.kt
+++ b/app/src/main/java/com/philkes/notallyx/utils/backup/AutoBackupWorker.kt
@@ -19,7 +19,7 @@ class AutoBackupWorker(private val context: Context, params: WorkerParameters) :
     Worker(context, params) {
 
     override fun doWork(): Result {
-        Log.i(TAG, "AutoBackupWorker: Start")
+        Log.d(TAG, "AutoBackupWorker: Start")
         val app = context.applicationContext as Application
         val preferences = NotallyXPreferences.getInstance(app)
         val (path, _, maxBackups) = preferences.autoBackup.value
@@ -42,12 +42,11 @@ class AutoBackupWorker(private val context: Context, params: WorkerParameters) :
                         }
                     }
 
-                    Log.i(TAG, "AutoBackupWorker: Success")
+                    Log.d(TAG, "AutoBackupWorker: Success")
                     return Result.success(
                         Data.Builder().putString("backupUri", zipUri.path!!).build()
                     )
                 } catch (e: Exception) {
-                    Log.e(TAG, "AutoBackupWorker: Failure", e)
                     Operations.log(app, e)
                     return Result.success(Data.Builder().putString("exception", e.message).build())
                 }

--- a/app/src/main/java/com/philkes/notallyx/utils/backup/Export.kt
+++ b/app/src/main/java/com/philkes/notallyx/utils/backup/Export.kt
@@ -42,7 +42,7 @@ object Export {
         backupProgress: MutableLiveData<Progress>? = null,
     ) {
         backupProgress?.postValue(Progress(indeterminate = true))
-        val database = NotallyDatabase.getDatabase(app).value
+        val database = NotallyDatabase.getDatabase(app, observeBiometricLock = false).value
         database.checkpoint()
         val preferences = NotallyXPreferences.getInstance(app)
         val backupPassword = preferences.backupPassword.value

--- a/app/src/main/java/com/philkes/notallyx/utils/backup/Import.kt
+++ b/app/src/main/java/com/philkes/notallyx/utils/backup/Import.kt
@@ -148,7 +148,7 @@ object Import {
                         }
                     }
 
-                    NotallyDatabase.getDatabase(app)
+                    NotallyDatabase.getDatabase(app, observeBiometricLock = false)
                         .value
                         .getCommonDao()
                         .importBackup(baseNotes, labels)


### PR DESCRIPTION
Fixes #101 

* `exportZip` no longer uncessarily tries to call `preferences.biometricLock.observeForever` which crashes since its run on a background thread
* Limits the extra log file for exceptions to be overwritten when it gets larger than 2kB