### PR TITLE
Fix delete selected notes forever

### DIFF
--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/main/fragment/ArchivedFragment.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/main/fragment/ArchivedFragment.kt
@@ -3,6 +3,7 @@ package com.philkes.notallyx.presentation.activity.main.fragment
 import android.os.Bundle
 import android.view.Menu
 import android.view.MenuInflater
+import android.view.View
 import androidx.navigation.fragment.findNavController
 import com.philkes.notallyx.R
 import com.philkes.notallyx.data.model.Folder
@@ -10,6 +11,11 @@ import com.philkes.notallyx.presentation.activity.main.fragment.SearchFragment.C
 import com.philkes.notallyx.presentation.add
 
 class ArchivedFragment : NotallyFragment() {
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        model.folder.value = Folder.ARCHIVED
+    }
 
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
         menu.add(R.string.search, R.drawable.search) {

--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/main/fragment/DeletedFragment.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/main/fragment/DeletedFragment.kt
@@ -3,6 +3,7 @@ package com.philkes.notallyx.presentation.activity.main.fragment
 import android.os.Bundle
 import android.view.Menu
 import android.view.MenuInflater
+import android.view.View
 import androidx.navigation.fragment.findNavController
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.philkes.notallyx.R
@@ -11,6 +12,11 @@ import com.philkes.notallyx.presentation.activity.main.fragment.SearchFragment.C
 import com.philkes.notallyx.presentation.add
 
 class DeletedFragment : NotallyFragment() {
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        model.folder.value = Folder.DELETED
+    }
 
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
         menu.add(R.string.delete_all, R.drawable.delete_all) { deleteAllNotes() }

--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/main/fragment/NotallyFragment.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/main/fragment/NotallyFragment.kt
@@ -159,7 +159,7 @@ abstract class NotallyFragment : Fragment(), ItemListener {
                 BaseNoteAdapter(
                     model.actionMode.selectedIds,
                     dateFormat.value,
-                    notesSorting.value.sortedBy,
+                    notesSorting.value,
                     textSize.value,
                     maxItems.value,
                     maxLines.value,
@@ -191,7 +191,7 @@ abstract class NotallyFragment : Fragment(), ItemListener {
         }
 
         model.preferences.notesSorting.observe(viewLifecycleOwner) { notesSort ->
-            notesAdapter?.setSorting(notesSort)
+            notesAdapter?.setNotesSort(notesSort)
         }
 
         model.actionMode.closeListener.observe(viewLifecycleOwner) { event ->

--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/main/fragment/NotesFragment.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/main/fragment/NotesFragment.kt
@@ -3,6 +3,7 @@ package com.philkes.notallyx.presentation.activity.main.fragment
 import android.os.Bundle
 import android.view.Menu
 import android.view.MenuInflater
+import android.view.View
 import androidx.navigation.fragment.findNavController
 import com.philkes.notallyx.R
 import com.philkes.notallyx.data.model.Folder
@@ -10,6 +11,11 @@ import com.philkes.notallyx.presentation.activity.main.fragment.SearchFragment.C
 import com.philkes.notallyx.presentation.add
 
 class NotesFragment : NotallyFragment() {
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        model.folder.value = Folder.NOTES
+    }
 
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
         menu.add(R.string.search, R.drawable.search) {

--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/main/fragment/SearchFragment.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/main/fragment/SearchFragment.kt
@@ -21,7 +21,7 @@ class SearchFragment : NotallyFragment() {
         super.onViewCreated(view, savedInstanceState)
 
         val checked =
-            when (initialFolder ?: model.folder) {
+            when (initialFolder ?: model.folder.value) {
                 Folder.NOTES -> R.id.Notes
                 Folder.DELETED -> R.id.Deleted
                 Folder.ARCHIVED -> R.id.Archived
@@ -30,9 +30,9 @@ class SearchFragment : NotallyFragment() {
         binding?.ChipGroup?.apply {
             setOnCheckedStateChangeListener { _, checkedId ->
                 when (checkedId.first()) {
-                    R.id.Notes -> model.folder = Folder.NOTES
-                    R.id.Deleted -> model.folder = Folder.DELETED
-                    R.id.Archived -> model.folder = Folder.ARCHIVED
+                    R.id.Notes -> model.folder.value = Folder.NOTES
+                    R.id.Deleted -> model.folder.value = Folder.DELETED
+                    R.id.Archived -> model.folder.value = Folder.ARCHIVED
                 }
             }
             check(checked)

--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/note/PickNoteActivity.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/note/PickNoteActivity.kt
@@ -44,7 +44,7 @@ open class PickNoteActivity : LockedActivity<ActivityPickNoteBinding>(), ItemLis
                 BaseNoteAdapter(
                     Collections.emptySet(),
                     dateFormat.value,
-                    notesSorting.value.sortedBy,
+                    notesSorting.value,
                     textSize.value,
                     maxItems.value,
                     maxLines.value,

--- a/app/src/main/java/com/philkes/notallyx/presentation/viewmodel/BaseNoteModel.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/viewmodel/BaseNoteModel.kt
@@ -362,7 +362,7 @@ class BaseNoteModel(private val app: Application) : AndroidViewModel(app) {
     }
 
     fun deleteSelectedBaseNotes() {
-        deleteBaseNotes(LongArray(actionMode.selectedNotes.size))
+        deleteBaseNotes(actionMode.selectedIds.toLongArray())
     }
 
     fun deleteAll() {

--- a/app/src/main/java/com/philkes/notallyx/presentation/viewmodel/BaseNoteModel.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/viewmodel/BaseNoteModel.kt
@@ -37,6 +37,7 @@ import com.philkes.notallyx.data.model.SearchResult
 import com.philkes.notallyx.data.model.Type
 import com.philkes.notallyx.presentation.applySpans
 import com.philkes.notallyx.presentation.getQuantityString
+import com.philkes.notallyx.presentation.view.misc.NotNullLiveData
 import com.philkes.notallyx.presentation.view.misc.Progress
 import com.philkes.notallyx.presentation.viewmodel.preference.AutoBackup
 import com.philkes.notallyx.presentation.viewmodel.preference.BasePreference
@@ -83,19 +84,13 @@ class BaseNoteModel(private val app: Application) : AndroidViewModel(app) {
     var deletedNotes: Content? = null
     var archivedNotes: Content? = null
 
-    var folder = Folder.NOTES
-        set(value) {
-            if (field != value) {
-                field = value
-                searchResults!!.fetch(keyword, folder)
-            }
-        }
+    val folder = NotNullLiveData(Folder.NOTES)
 
     var keyword = String()
         set(value) {
             if (field != value || searchResults?.value?.isEmpty() == true) {
                 field = value
-                searchResults!!.fetch(keyword, folder)
+                searchResults!!.fetch(keyword, folder.value)
             }
         }
 
@@ -118,6 +113,7 @@ class BaseNoteModel(private val app: Application) : AndroidViewModel(app) {
 
     init {
         NotallyDatabase.getDatabase(app).observeForever(::init)
+        folder.observeForever { newFolder -> searchResults!!.fetch(keyword, newFolder) }
     }
 
     private fun init(database: NotallyDatabase) {


### PR DESCRIPTION
Fixes #117 

* Pass correct note ids to delete forever
* Show useful actions in the Folders: `NOTES`: `Pin`, `Label`, `Delete`, `ARCHIVED`: `Unarchive`, `Delete`, `Export`, `DELETED`: `Restore`, `Delete Forever`. All other actions are hidden in the "..." menu