### PR TITLE
Add setting to store all data on external storage

### DIFF
--- a/app/src/main/java/com/philkes/notallyx/NotallyXApplication.kt
+++ b/app/src/main/java/com/philkes/notallyx/NotallyXApplication.kt
@@ -8,9 +8,9 @@ import android.os.Build
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.lifecycle.Observer
 import com.philkes.notallyx.presentation.view.misc.NotNullLiveData
-import com.philkes.notallyx.presentation.viewmodel.preference.AutoBackup
 import com.philkes.notallyx.presentation.viewmodel.preference.BiometricLock
 import com.philkes.notallyx.presentation.viewmodel.preference.NotallyXPreferences
+import com.philkes.notallyx.presentation.viewmodel.preference.NotallyXPreferences.Companion.EMPTY_PATH
 import com.philkes.notallyx.presentation.viewmodel.preference.Theme
 import com.philkes.notallyx.presentation.widget.WidgetProvider
 import com.philkes.notallyx.utils.backup.Export.cancelAutoBackup
@@ -42,7 +42,7 @@ class NotallyXApplication : Application() {
         }
 
         preferences.autoBackup.observeForeverWithPrevious { (prevAutoBackup, autoBackup) ->
-            if (autoBackup.path == AutoBackup.BACKUP_PATH_EMPTY) {
+            if (autoBackup.path == EMPTY_PATH) {
                 cancelAutoBackup(this)
             } else {
                 if (

--- a/app/src/main/java/com/philkes/notallyx/data/NotallyDatabase.kt
+++ b/app/src/main/java/com/philkes/notallyx/data/NotallyDatabase.kt
@@ -20,7 +20,9 @@ import com.philkes.notallyx.presentation.view.misc.NotNullLiveData
 import com.philkes.notallyx.presentation.viewmodel.preference.BiometricLock
 import com.philkes.notallyx.presentation.viewmodel.preference.NotallyXPreferences
 import com.philkes.notallyx.presentation.viewmodel.preference.observeForeverSkipFirst
+import com.philkes.notallyx.utils.IO.getExternalMediaDirectory
 import com.philkes.notallyx.utils.security.getInitializedCipherForDecryption
+import java.io.File
 import net.sqlcipher.database.SupportFactory
 
 @TypeConverters(Converters::class)
@@ -38,6 +40,7 @@ abstract class NotallyDatabase : RoomDatabase() {
     }
 
     private var biometricLockObserver: Observer<BiometricLock>? = null
+    private var externalDataFolderObserver: Observer<Boolean>? = null
 
     companion object {
 
@@ -45,22 +48,47 @@ abstract class NotallyDatabase : RoomDatabase() {
 
         @Volatile private var instance: NotNullLiveData<NotallyDatabase>? = null
 
+        fun getCurrentDatabaseFile(app: Application): File {
+            return if (NotallyXPreferences.getInstance(app).dataOnExternalStorage.value) {
+                getExternalDatabaseFile(app)
+            } else {
+                getInternalDatabaseFile(app)
+            }
+        }
+
+        fun getExternalDatabaseFile(app: Application): File {
+            return File(app.getExternalMediaDirectory(), DatabaseName)
+        }
+
+        fun getExternalDatabaseFiles(app: Application): List<File> {
+            return listOf(
+                File(app.getExternalMediaDirectory(), DatabaseName),
+                File(app.getExternalMediaDirectory(), "$DatabaseName-shm"),
+                File(app.getExternalMediaDirectory(), "$DatabaseName-wal"),
+            )
+        }
+
+        fun getInternalDatabaseFile(app: Application): File {
+            return app.getDatabasePath(DatabaseName)
+        }
+
+        fun getCurrentDatabaseName(app: Application): String {
+            return if (NotallyXPreferences.getInstance(app).dataOnExternalStorage.value) {
+                getExternalDatabaseFile(app).absolutePath
+            } else {
+                DatabaseName
+            }
+        }
+
         fun getDatabase(
             app: Application,
-            observeBiometricLock: Boolean = true,
+            observePreferences: Boolean = true,
         ): NotNullLiveData<NotallyDatabase> {
             return instance
                 ?: synchronized(this) {
                     val preferences = NotallyXPreferences.getInstance(app)
                     this.instance =
-                        NotNullLiveData(
-                            createInstance(
-                                app,
-                                preferences,
-                                preferences.biometricLock.value,
-                                observeBiometricLock,
-                            )
-                        )
+                        NotNullLiveData(createInstance(app, preferences, observePreferences))
                     return this.instance!!
                 }
         }
@@ -68,14 +96,13 @@ abstract class NotallyDatabase : RoomDatabase() {
         private fun createInstance(
             app: Application,
             preferences: NotallyXPreferences,
-            biometrickLock: BiometricLock,
-            observeBiometricLock: Boolean,
+            observePreferences: Boolean,
         ): NotallyDatabase {
             val instanceBuilder =
-                Room.databaseBuilder(app, NotallyDatabase::class.java, DatabaseName)
+                Room.databaseBuilder(app, NotallyDatabase::class.java, getCurrentDatabaseName(app))
                     .addMigrations(Migration2, Migration3, Migration4, Migration5, Migration6)
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                if (biometrickLock == BiometricLock.ENABLED) {
+                if (preferences.biometricLock.value == BiometricLock.ENABLED) {
                     val initializationVector = preferences.iv.value!!
                     val cipher = getInitializedCipherForDecryption(iv = initializationVector)
                     val encryptedPassphrase = preferences.databaseEncryptionKey.value
@@ -84,12 +111,12 @@ abstract class NotallyDatabase : RoomDatabase() {
                     instanceBuilder.openHelperFactory(factory)
                 }
                 val instance = instanceBuilder.build()
-                if (observeBiometricLock) {
-                    instance.biometricLockObserver = Observer { newBiometrickLock ->
+                if (observePreferences) {
+                    instance.biometricLockObserver = Observer {
                         NotallyDatabase.instance?.value?.biometricLockObserver?.let {
                             preferences.biometricLock.removeObserver(it)
                         }
-                        val newInstance = createInstance(app, preferences, newBiometrickLock, true)
+                        val newInstance = createInstance(app, preferences, true)
                         NotallyDatabase.instance?.postValue(newInstance)
                         preferences.biometricLock.observeForeverSkipFirst(
                             newInstance.biometricLockObserver!!
@@ -97,6 +124,20 @@ abstract class NotallyDatabase : RoomDatabase() {
                     }
                     preferences.biometricLock.observeForeverSkipFirst(
                         instance.biometricLockObserver!!
+                    )
+
+                    instance.externalDataFolderObserver = Observer {
+                        NotallyDatabase.instance?.value?.externalDataFolderObserver?.let {
+                            preferences.dataOnExternalStorage.removeObserver(it)
+                        }
+                        val newInstance = createInstance(app, preferences, true)
+                        NotallyDatabase.instance?.postValue(newInstance)
+                        preferences.dataOnExternalStorage.observeForeverSkipFirst(
+                            newInstance.externalDataFolderObserver!!
+                        )
+                    }
+                    preferences.dataOnExternalStorage.observeForeverSkipFirst(
+                        instance.externalDataFolderObserver!!
                     )
                 }
                 return instance

--- a/app/src/main/java/com/philkes/notallyx/presentation/viewmodel/preference/AutoBackup.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/viewmodel/preference/AutoBackup.kt
@@ -2,6 +2,7 @@ package com.philkes.notallyx.presentation.viewmodel.preference
 
 import android.content.SharedPreferences
 import android.content.SharedPreferences.Editor
+import com.philkes.notallyx.presentation.viewmodel.preference.NotallyXPreferences.Companion.EMPTY_PATH
 
 class AutoBackupPreference(sharedPreferences: SharedPreferences) :
     BasePreference<AutoBackup>(sharedPreferences, AutoBackup()) {
@@ -28,12 +29,11 @@ class AutoBackupPreference(sharedPreferences: SharedPreferences) :
 }
 
 data class AutoBackup(
-    val path: String = BACKUP_PATH_EMPTY,
+    val path: String = EMPTY_PATH,
     val periodInDays: Int = BACKUP_PERIOD_DAYS_MIN,
     val maxBackups: Int = 3,
 ) {
     companion object {
-        const val BACKUP_PATH_EMPTY = "emptyPath"
 
         const val BACKUP_PERIOD_DAYS_MIN = 1
         const val BACKUP_PERIOD_DAYS_MAX = 31

--- a/app/src/main/java/com/philkes/notallyx/presentation/viewmodel/preference/NotallyXPreferences.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/viewmodel/preference/NotallyXPreferences.kt
@@ -102,6 +102,9 @@ class NotallyXPreferences private constructor(app: Application) {
     val databaseEncryptionKey =
         EncryptedPassphrasePreference("database_encryption_key", preferences, ByteArray(0))
 
+    val dataOnExternalStorage =
+        BooleanPreference("dataOnExternalStorage", preferences, false, R.string.data_on_external)
+
     fun getWidgetData(id: Int) = preferences.getLong("widget:$id", 0)
 
     fun getWidgetNoteType(id: Int) =
@@ -148,6 +151,7 @@ class NotallyXPreferences private constructor(app: Application) {
     }
 
     companion object {
+        const val EMPTY_PATH = "emptyPath"
 
         @Volatile private var instance: NotallyXPreferences? = null
 

--- a/app/src/main/java/com/philkes/notallyx/presentation/viewmodel/preference/Preference.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/viewmodel/preference/Preference.kt
@@ -191,6 +191,22 @@ class StringPreference(
     }
 }
 
+class BooleanPreference(
+    private val key: String,
+    sharedPreferences: SharedPreferences,
+    defaultValue: Boolean,
+    titleResId: Int? = null,
+) : BasePreference<Boolean>(sharedPreferences, defaultValue, titleResId) {
+
+    override fun getValue(sharedPreferences: SharedPreferences): Boolean {
+        return sharedPreferences.getBoolean(key, defaultValue)
+    }
+
+    override fun SharedPreferences.Editor.put(value: Boolean) {
+        putBoolean(key, value)
+    }
+}
+
 class ByteArrayPreference(
     private val key: String,
     sharedPreferences: SharedPreferences,

--- a/app/src/main/java/com/philkes/notallyx/presentation/widget/WidgetProvider.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/widget/WidgetProvider.kt
@@ -58,7 +58,7 @@ class WidgetProvider : AppWidgetProvider() {
         val database =
             NotallyDatabase.getDatabase(
                     context.applicationContext as Application,
-                    observeBiometricLock = false,
+                    observePreferences = false,
                 )
                 .value
         val pendingResult = goAsync()

--- a/app/src/main/java/com/philkes/notallyx/utils/IO.kt
+++ b/app/src/main/java/com/philkes/notallyx/utils/IO.kt
@@ -15,6 +15,7 @@ import com.philkes.notallyx.data.model.FileAttachment
 import com.philkes.notallyx.data.model.isImage
 import com.philkes.notallyx.presentation.view.misc.Progress
 import com.philkes.notallyx.presentation.widget.WidgetProvider
+import com.philkes.notallyx.utils.IO.createDirectory
 import java.io.File
 import java.io.FileOutputStream
 import java.io.InputStream
@@ -28,11 +29,13 @@ object IO {
     const val SUBFOLDER_FILES = "Files"
     const val SUBFOLDER_AUDIOS = "Audios"
 
-    fun Application.getExternalImagesDirectory() = getExternalDirectory(SUBFOLDER_IMAGES)
+    fun Application.getExternalImagesDirectory() = getExternalMediaDirectory(SUBFOLDER_IMAGES)
 
-    fun Application.getExternalAudioDirectory() = getExternalDirectory(SUBFOLDER_AUDIOS)
+    fun Application.getExternalAudioDirectory() = getExternalMediaDirectory(SUBFOLDER_AUDIOS)
 
-    fun Application.getExternalFilesDirectory() = getExternalDirectory(SUBFOLDER_FILES)
+    fun Application.getExternalFilesDirectory() = getExternalMediaDirectory(SUBFOLDER_FILES)
+
+    fun Application.getExternalMediaDirectory() = getExternalMediaDirectory("")
 
     fun Context.getTempAudioFile(): File {
         return File(externalCacheDir, "Temp.m4a")
@@ -130,20 +133,20 @@ object IO {
 
     fun Application.getExportedPath() = getEmptyFolder("exported")
 
-    private fun Application.getExternalDirectory(name: String): File? {
-        var file: File? = null
+    private fun Application.getExternalMediaDirectory(name: String): File? {
+        return externalMediaDirs.firstOrNull()?.let { getDirectory(it, name) }
+    }
 
+    private fun getDirectory(dir: File, name: String): File? {
+        var file: File? = null
         try {
-            val mediaDir = externalMediaDirs.firstOrNull()
-            if (mediaDir != null) {
-                file = File(mediaDir, name)
-                if (file.exists()) {
-                    if (!file.isDirectory) {
-                        file.delete()
-                        file.createDirectory()
-                    }
-                } else file.createDirectory()
-            }
+            file = File(dir, name)
+            if (file.exists()) {
+                if (!file.isDirectory) {
+                    file.delete()
+                    file.createDirectory()
+                }
+            } else file.createDirectory()
         } catch (exception: Exception) {
             exception.printStackTrace()
         }

--- a/app/src/main/java/com/philkes/notallyx/utils/backup/AutoBackupWorker.kt
+++ b/app/src/main/java/com/philkes/notallyx/utils/backup/AutoBackupWorker.kt
@@ -8,8 +8,8 @@ import androidx.documentfile.provider.DocumentFile
 import androidx.work.Data
 import androidx.work.Worker
 import androidx.work.WorkerParameters
-import com.philkes.notallyx.presentation.viewmodel.preference.AutoBackup
 import com.philkes.notallyx.presentation.viewmodel.preference.NotallyXPreferences
+import com.philkes.notallyx.presentation.viewmodel.preference.NotallyXPreferences.Companion.EMPTY_PATH
 import com.philkes.notallyx.utils.Operations
 import com.philkes.notallyx.utils.backup.Export.exportAsZip
 import java.text.SimpleDateFormat
@@ -24,7 +24,7 @@ class AutoBackupWorker(private val context: Context, params: WorkerParameters) :
         val preferences = NotallyXPreferences.getInstance(app)
         val (path, _, maxBackups) = preferences.autoBackup.value
 
-        if (path != AutoBackup.BACKUP_PATH_EMPTY) {
+        if (path != EMPTY_PATH) {
             val uri = Uri.parse(path)
             val folder = requireNotNull(DocumentFile.fromTreeUri(app, uri))
 

--- a/app/src/main/java/com/philkes/notallyx/utils/backup/Import.kt
+++ b/app/src/main/java/com/philkes/notallyx/utils/backup/Import.kt
@@ -148,7 +148,7 @@ object Import {
                         }
                     }
 
-                    NotallyDatabase.getDatabase(app, observeBiometricLock = false)
+                    NotallyDatabase.getDatabase(app, observePreferences = false)
                         .value
                         .getCommonDao()
                         .importBackup(baseNotes, labels)

--- a/app/src/main/java/com/philkes/notallyx/utils/security/EncryptionUtils.kt
+++ b/app/src/main/java/com/philkes/notallyx/utils/security/EncryptionUtils.kt
@@ -31,10 +31,15 @@ fun decryptDatabase(context: Context, passphrase: ByteArray) {
     }
 }
 
-fun decryptDatabase(context: Context, passphrase: ByteArray, decryptedFile: File) {
-    val state = SQLCipherUtils.getDatabaseState(context, DatabaseName)
+fun decryptDatabase(
+    context: Context,
+    passphrase: ByteArray,
+    decryptedFile: File,
+    databaseName: String,
+) {
+    val state = SQLCipherUtils.getDatabaseState(context, databaseName)
     if (state == SQLCipherUtils.State.ENCRYPTED) {
-        SQLCipherUtils.decrypt(context, DatabaseName, decryptedFile, passphrase)
+        SQLCipherUtils.decrypt(context, databaseName, decryptedFile, passphrase)
     }
 }
 

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -117,6 +117,11 @@
           android:layout_height="wrap_content"
           android:text="@string/clear_data" />
 
+
+        <include
+          android:id="@+id/ExternalDataFolder"
+          layout="@layout/preference" />
+
         <View
             android:layout_width="match_parent"
             android:layout_height="1dp"

--- a/app/src/main/res/layout/preference_boolean_dialog.xml
+++ b/app/src/main/res/layout/preference_boolean_dialog.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  android:layout_width="match_parent"
+  android:layout_height="wrap_content"
+  android:orientation="vertical"
+  android:paddingTop="8dp"
+  android:paddingStart="26dp"
+  android:paddingEnd="26dp"
+  >
+
+  <TextView
+    android:id="@+id/Title"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:textAppearance="?attr/textAppearanceSubtitle2"
+    android:textSize="16sp"
+    android:paddingBottom="8dp"
+    android:layout_marginTop="12dp"
+    />
+
+  <TextView
+    android:id="@+id/Message"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:textAppearance="?attr/textAppearanceCaption"
+    android:textSize="16sp"
+    android:paddingBottom="8dp"
+    android:layout_marginTop="12dp"
+    />
+
+  <RadioGroup
+    android:id="@+id/RadioGroup"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    >
+    <RadioButton
+      android:id="@+id/EnabledButton"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:minHeight="?attr/listPreferredItemHeightSmall"
+      android:textAppearance="?android:attr/textAppearanceMedium"
+      android:textColor="?attr/textColorAlertDialogListItem"
+      android:gravity="center_vertical"
+      android:paddingLeft="@dimen/abc_select_dialog_padding_start_material"
+      android:paddingRight="?attr/dialogPreferredPadding"
+      android:paddingStart="@dimen/abc_select_dialog_padding_start_material"
+      android:paddingEnd="?attr/dialogPreferredPadding"
+      android:drawablePadding="4dp"
+      android:ellipsize="marquee"
+      android:text="@string/enabled"/>
+
+    <RadioButton
+      android:id="@+id/DisabledButton"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:minHeight="?attr/listPreferredItemHeightSmall"
+      android:textAppearance="?android:attr/textAppearanceMedium"
+      android:textColor="?attr/textColorAlertDialogListItem"
+      android:gravity="center_vertical"
+      android:paddingLeft="@dimen/abc_select_dialog_padding_start_material"
+      android:paddingRight="?attr/dialogPreferredPadding"
+      android:paddingStart="@dimen/abc_select_dialog_padding_start_material"
+      android:paddingEnd="?attr/dialogPreferredPadding"
+      android:drawablePadding="4dp"
+      android:ellipsize="marquee"
+      android:text="@string/disabled" />
+  </RadioGroup>
+
+
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -216,6 +216,10 @@
     <string name="weekly">Weekly</string>
     <string name="monthly">Monthly</string>
 
+    <string name="data_on_external">Store Data on External Storage</string>
+    <string name="external_data_message">By enabling this, the app’s internal database will be moved into the app’s external storage (Android/media/com.philkes.notallyx).\nIn combination with file synchronization apps this can be used to synchronize NotallyX data between multiple devices.</string>
+    <string name="disable_external_data">Move data back to internal storage</string>
+
     <string name="about">About</string>
     <string name="libraries">Libraries</string>
     <string name="choose_other_app">Choose which app to import from</string>

--- a/app/src/main/res/xml/provider_paths.xml
+++ b/app/src/main/res/xml/provider_paths.xml
@@ -7,6 +7,9 @@
         name="logs"
         path="/logs" />
     <external-media-path
+      name="."
+      path="." />
+    <external-media-path
         name="images"
         path="/Images" />
     <external-media-path


### PR DESCRIPTION
Closes #109 

* Adds preference to move all internal data to external storage. This can be used to synchronize the data across multiple devices, or even make backups with other external apps or webdav shares.

![image](https://github.com/user-attachments/assets/fc997e92-df6d-4d67-9ef1-0820fafe191e)
