### PR TITLE
Add plain text importer + export multiple notes

### DIFF
--- a/app/src/main/java/com/philkes/notallyx/data/imports/ExternalImporter.kt
+++ b/app/src/main/java/com/philkes/notallyx/data/imports/ExternalImporter.kt
@@ -11,12 +11,13 @@ interface ExternalImporter {
     /**
      * Parses [BaseNote]s from [source] and copies attached files/images/audios to [destination]
      *
-     * @return List of [BaseNote]s to import + folder containing attached files
+     * @return List of [BaseNote]s to import + folder containing attached files (if no attached
+     *   files possible, return null).
      */
     fun import(
         app: Application,
         source: Uri,
         destination: File,
         progress: MutableLiveData<ImportProgress>? = null,
-    ): Pair<List<BaseNote>, File>
+    ): Pair<List<BaseNote>, File?>
 }

--- a/app/src/main/java/com/philkes/notallyx/data/imports/txt/PlainTextImporter.kt
+++ b/app/src/main/java/com/philkes/notallyx/data/imports/txt/PlainTextImporter.kt
@@ -1,0 +1,97 @@
+package com.philkes.notallyx.data.imports.txt
+
+import android.app.Application
+import android.net.Uri
+import androidx.documentfile.provider.DocumentFile
+import androidx.lifecycle.MutableLiveData
+import com.philkes.notallyx.data.imports.ExternalImporter
+import com.philkes.notallyx.data.imports.ImportProgress
+import com.philkes.notallyx.data.model.BaseNote
+import com.philkes.notallyx.data.model.Color
+import com.philkes.notallyx.data.model.Folder
+import com.philkes.notallyx.data.model.ListItem
+import com.philkes.notallyx.data.model.Type
+import java.io.BufferedReader
+import java.io.File
+import java.io.InputStreamReader
+
+class PlainTextImporter : ExternalImporter {
+
+    override fun import(
+        app: Application,
+        source: Uri,
+        destination: File,
+        progress: MutableLiveData<ImportProgress>?,
+    ): Pair<List<BaseNote>, File?> {
+        val notes = mutableListOf<BaseNote>()
+        fun readTxtFiles(folder: DocumentFile) {
+            folder.listFiles().forEach { file ->
+                when {
+                    file.isDirectory -> {
+                        readTxtFiles(file)
+                    }
+
+                    file.isFile -> {
+                        val fileNameWithoutExtension = file.name?.substringBeforeLast(".") ?: ""
+                        var content =
+                            app.contentResolver.openInputStream(file.uri)?.use { inputStream ->
+                                BufferedReader(InputStreamReader(inputStream)).use { reader ->
+                                    reader.readText()
+                                }
+                            } ?: ""
+                        val listItems = mutableListOf<ListItem>()
+                        content.findListSyntaxRegex()?.let { listSyntaxRegex ->
+                            listItems.addAll(content.extractListItems(listSyntaxRegex))
+                            content = ""
+                        }
+                        val timestamp = System.currentTimeMillis()
+                        notes.add(
+                            BaseNote(
+                                id = 0L, // Auto-generated
+                                type = if (listItems.isEmpty()) Type.NOTE else Type.LIST,
+                                folder = Folder.NOTES,
+                                color = Color.DEFAULT,
+                                title = fileNameWithoutExtension,
+                                pinned = false,
+                                timestamp = timestamp,
+                                modifiedTimestamp = timestamp,
+                                labels = listOf(),
+                                body = content,
+                                spans = listOf(),
+                                items = listItems,
+                                images = listOf(),
+                                files = listOf(),
+                                audios = listOf(),
+                            )
+                        )
+                    }
+                }
+            }
+        }
+        DocumentFile.fromTreeUri(app, source)?.let { readTxtFiles(it) }
+
+        return Pair(notes, null)
+    }
+
+    fun String.extractListItems(regex: Regex): List<ListItem> {
+        return regex
+            .findAll(this)
+            .mapIndexed { idx, matchResult ->
+                val isChild = matchResult.groupValues[1] != ""
+                val isChecked = matchResult.groupValues[2] != ""
+                val itemText = matchResult.groupValues[3]
+                ListItem(itemText.trimStart(), isChecked, isChild, idx, mutableListOf())
+            }
+            .toList()
+    }
+
+    fun String.findListSyntaxRegex(): Regex? {
+        if (startsWith("[ ]") || startsWith("[✓]")) {
+            return "\n?(\\s*)\\[ ?(✓?)\\](.*)".toRegex()
+        }
+        if (startsWith("- [ ]") || startsWith("- [x]", ignoreCase = true)) {
+            return "\n?(\\s*)- \\[ ?([xX]?)\\](.*)".toRegex()
+        }
+        return null
+    }
+}

--- a/app/src/main/java/com/philkes/notallyx/data/model/ModelExtensions.kt
+++ b/app/src/main/java/com/philkes/notallyx/data/model/ModelExtensions.kt
@@ -1,6 +1,13 @@
 package com.philkes.notallyx.data.model
 
+import android.text.Html
 import android.util.Patterns
+import androidx.core.text.toHtml
+import com.philkes.notallyx.presentation.applySpans
+import com.philkes.notallyx.utils.Operations
+import java.text.DateFormat
+import org.json.JSONArray
+import org.json.JSONObject
 
 fun CharSequence?.isWebUrl(): Boolean {
     return this?.let { Patterns.WEB_URL.matcher(this).matches() } ?: false
@@ -60,3 +67,80 @@ val ByteArray.toPreservedString: String
     get() {
         return String(this, Charsets.ISO_8859_1)
     }
+
+fun BaseNote.toTxt(includeTitle: Boolean = true, includeCreationDate: Boolean = true) =
+    buildString {
+        val date = DateFormat.getDateInstance(DateFormat.FULL).format(timestamp)
+        val body =
+            when (type) {
+                Type.NOTE -> body
+                Type.LIST -> Operations.getBody(items)
+            }
+
+        if (title.isNotEmpty() && includeTitle) {
+            append("${title}\n\n")
+        }
+        if (includeCreationDate) {
+            append("$date\n\n")
+        }
+        append(body)
+        return toString()
+    }
+
+fun BaseNote.toJson(): String {
+    val jsonObject =
+        JSONObject()
+            .put("type", type.name)
+            .put("color", color.name)
+            .put("title", title)
+            .put("pinned", pinned)
+            .put("date-created", timestamp)
+            .put("labels", JSONArray(labels))
+
+    when (type) {
+        Type.NOTE -> {
+            jsonObject.put("body", body)
+            jsonObject.put("spans", Converters.spansToJSONArray(spans))
+        }
+
+        Type.LIST -> {
+            jsonObject.put("items", Converters.itemsToJSONArray(items))
+        }
+    }
+
+    return jsonObject.toString(2)
+}
+
+fun BaseNote.toHtml(showDateCreated: Boolean) = buildString {
+    val date = DateFormat.getDateInstance(DateFormat.FULL).format(timestamp)
+    val title = Html.escapeHtml(title)
+
+    append("<!DOCTYPE html>")
+    append("<html><head>")
+    append("<meta charset=\"UTF-8\"><title>$title</title>")
+    append("</head><body>")
+    append("<h2>$title</h2>")
+
+    if (showDateCreated) {
+        append("<p>$date</p>")
+    }
+
+    when (type) {
+        Type.NOTE -> {
+            val body = body.applySpans(spans).toHtml()
+            append(body)
+        }
+
+        Type.LIST -> {
+            append("<ol style=\"list-style: none; padding: 0;\">")
+            items.forEach { item ->
+                val body = Html.escapeHtml(item.body)
+                val checked = if (item.checked) "checked" else ""
+                val child = if (item.isChild) "style=\"margin-left: 20px\"" else ""
+                append("<li><input type=\"checkbox\" $child $checked>$body</li>")
+            }
+            append("</ol>")
+        }
+    }
+    append("</body></html>")
+}

--- a/app/src/main/java/com/philkes/notallyx/presentation/UiExtensions.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/UiExtensions.kt
@@ -40,6 +40,8 @@ import android.widget.RadioGroup
 import android.widget.TextView
 import androidx.appcompat.app.AlertDialog
 import androidx.core.content.ContextCompat
+import androidx.core.content.FileProvider
+import androidx.documentfile.provider.DocumentFile
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.MutableLiveData
@@ -475,3 +477,9 @@ fun MaterialAlertDialogBuilder.showAndFocus(view: View): AlertDialog {
 fun Context.getQuantityString(id: Int, quantity: Int, vararg formatArgs: Any): String {
     return resources.getQuantityString(id, quantity, quantity, *formatArgs)
 }
+
+fun Context.getUriForFile(file: File): Uri =
+    FileProvider.getUriForFile(this, "${packageName}.provider", file)
+
+val DocumentFile.nameWithoutExtension: String?
+    get() = name?.substringBeforeLast(".")

--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/main/fragment/SettingsFragment.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/main/fragment/SettingsFragment.kt
@@ -18,7 +18,6 @@ import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity.RESULT_OK
 import androidx.core.content.ContextCompat
-import androidx.core.content.FileProvider
 import androidx.documentfile.provider.DocumentFile
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
@@ -37,6 +36,7 @@ import com.philkes.notallyx.databinding.PreferenceSeekbarBinding
 import com.philkes.notallyx.databinding.TextInputDialogBinding
 import com.philkes.notallyx.presentation.canAuthenticateWithBiometrics
 import com.philkes.notallyx.presentation.checkedTag
+import com.philkes.notallyx.presentation.getUriForFile
 import com.philkes.notallyx.presentation.setupImportProgressDialog
 import com.philkes.notallyx.presentation.setupProgressDialog
 import com.philkes.notallyx.presentation.view.misc.MenuDialog
@@ -399,7 +399,7 @@ class SettingsFragment : Fragment() {
         val app = requireContext().applicationContext as Application
         val log = Operations.getLog(app)
         if (log.exists()) {
-            val uri = FileProvider.getUriForFile(app, "${app.packageName}.provider", log)
+            val uri = app.getUriForFile(log)
             intent.putExtra(Intent.EXTRA_STREAM, uri)
         }
 

--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/main/fragment/SettingsFragment.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/main/fragment/SettingsFragment.kt
@@ -26,6 +26,7 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.textfield.TextInputLayout.END_ICON_PASSWORD_TOGGLE
 import com.philkes.notallyx.NotallyXApplication
 import com.philkes.notallyx.R
+import com.philkes.notallyx.data.imports.FOLDER_MIMETYPE
 import com.philkes.notallyx.data.imports.ImportSource
 import com.philkes.notallyx.databinding.ChoiceItemBinding
 import com.philkes.notallyx.databinding.FragmentSettingsBinding
@@ -315,22 +316,32 @@ class SettingsFragment : Fragment() {
                     .setPositiveButton(R.string.import_action) { dialog, _ ->
                         dialog.cancel()
                         val intent =
-                            Intent(Intent.ACTION_OPEN_DOCUMENT).apply {
-                                type = "ap/*"
-                                putExtra(
-                                    Intent.EXTRA_MIME_TYPES,
-                                    arrayOf(selectedImportSource.mimeType),
-                                )
-                                addCategory(Intent.CATEGORY_OPENABLE)
+                            when (selectedImportSource.mimeType) {
+                                FOLDER_MIMETYPE ->
+                                    Intent(Intent.ACTION_OPEN_DOCUMENT_TREE).apply {
+                                        addCategory(Intent.CATEGORY_DEFAULT)
+                                    }
+
+                                else ->
+                                    Intent(Intent.ACTION_OPEN_DOCUMENT).apply {
+                                        type = "application/*"
+                                        putExtra(
+                                            Intent.EXTRA_MIME_TYPES,
+                                            arrayOf(selectedImportSource.mimeType),
+                                        )
+                                        addCategory(Intent.CATEGORY_OPENABLE)
+                                    }
                             }
                         importOtherActivityResultLauncher.launch(intent)
                     }
-                    .setNegativeButton(R.string.help) { _, _ ->
-                        val intent =
-                            Intent(Intent.ACTION_VIEW).apply {
-                                data = Uri.parse(selectedImportSource.documentationUrl)
+                    .also {
+                        selectedImportSource.documentationUrl?.let { docUrl ->
+                            it.setNegativeButton(R.string.help) { _, _ ->
+                                val intent =
+                                    Intent(Intent.ACTION_VIEW).apply { data = Uri.parse(docUrl) }
+                                startActivity(intent)
                             }
-                        startActivity(intent)
+                        }
                     }
                     .setNeutralButton(R.string.cancel) { dialog, _ -> dialog.cancel() }
                     .show()

--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/note/EditActivity.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/note/EditActivity.kt
@@ -19,7 +19,6 @@ import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.annotation.RequiresApi
-import androidx.core.content.FileProvider
 import androidx.core.content.IntentCompat
 import androidx.core.view.isVisible
 import androidx.lifecycle.lifecycleScope
@@ -37,6 +36,7 @@ import com.philkes.notallyx.presentation.activity.LockedActivity
 import com.philkes.notallyx.presentation.add
 import com.philkes.notallyx.presentation.displayFormattedTimestamp
 import com.philkes.notallyx.presentation.getQuantityString
+import com.philkes.notallyx.presentation.getUriForFile
 import com.philkes.notallyx.presentation.setupProgressDialog
 import com.philkes.notallyx.presentation.view.Constants
 import com.philkes.notallyx.presentation.view.note.ErrorAdapter
@@ -491,12 +491,7 @@ abstract class EditActivity(private val type: Type) : LockedActivity<ActivityEdi
                 val intent =
                     Intent(Intent.ACTION_VIEW).apply {
                         val file = File(model.filesRoot, fileAttachment.localName)
-                        val uri =
-                            FileProvider.getUriForFile(
-                                this@EditActivity,
-                                "${packageName}.provider",
-                                file,
-                            )
+                        val uri = this@EditActivity.getUriForFile(file)
                         setDataAndType(uri, fileAttachment.mimeType)
                         addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
                     }

--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/note/PlayAudioActivity.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/note/PlayAudioActivity.kt
@@ -9,7 +9,6 @@ import android.os.IBinder
 import android.widget.Toast
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.core.content.FileProvider
 import androidx.core.content.IntentCompat
 import androidx.lifecycle.lifecycleScope
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
@@ -18,6 +17,7 @@ import com.philkes.notallyx.data.model.Audio
 import com.philkes.notallyx.databinding.ActivityPlayAudioBinding
 import com.philkes.notallyx.presentation.activity.LockedActivity
 import com.philkes.notallyx.presentation.add
+import com.philkes.notallyx.presentation.getUriForFile
 import com.philkes.notallyx.utils.IO.getExternalAudioDirectory
 import com.philkes.notallyx.utils.audio.AudioPlayService
 import com.philkes.notallyx.utils.audio.LocalBinder
@@ -112,7 +112,7 @@ class PlayAudioActivity : LockedActivity<ActivityPlayAudioBinding>() {
         val audioRoot = application.getExternalAudioDirectory()
         val file = if (audioRoot != null) File(audioRoot, audio.name) else null
         if (file != null && file.exists()) {
-            val uri = FileProvider.getUriForFile(this, "$packageName.provider", file)
+            val uri = getUriForFile(file)
 
             val intent =
                 Intent(Intent.ACTION_SEND).apply {

--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/note/ViewImageActivity.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/note/ViewImageActivity.kt
@@ -7,7 +7,6 @@ import android.os.Bundle
 import android.widget.Toast
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.core.content.FileProvider
 import androidx.core.os.BundleCompat
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -21,6 +20,7 @@ import com.philkes.notallyx.data.model.FileAttachment
 import com.philkes.notallyx.databinding.ActivityViewImageBinding
 import com.philkes.notallyx.presentation.activity.LockedActivity
 import com.philkes.notallyx.presentation.add
+import com.philkes.notallyx.presentation.getUriForFile
 import com.philkes.notallyx.presentation.view.Constants
 import com.philkes.notallyx.presentation.view.note.image.ImageAdapter
 import com.philkes.notallyx.utils.IO.getExternalImagesDirectory
@@ -154,7 +154,7 @@ class ViewImageActivity : LockedActivity<ActivityViewImageBinding>() {
         val mediaRoot = application.getExternalImagesDirectory()
         val file = if (mediaRoot != null) File(mediaRoot, image.localName) else null
         if (file != null && file.exists()) {
-            val uri = FileProvider.getUriForFile(this, "$packageName.provider", file)
+            val uri = getUriForFile(file)
 
             val intent =
                 Intent(Intent.ACTION_SEND).apply {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -190,6 +190,7 @@
     <string name="help">Help</string>
     <string name="google_keep_help">In order to import your Notes from Google Keep you must download your Google Takeout ZIP file. Click Help to get more information.\n\nIf you already have a Takeout ZIP file, click Import and choose the ZIP file.</string>
     <string name="evernote_help">In order to import your Notes from Evernote you must export your Evernote Notebook as ENEX. Click Help to get more information.\n\nIf you already have a ENEX file, click Import and choose it.</string>
+    <string name="plain_text_files_help">In order to import your Notes from plain text files, click Import and choose the folder containing the text files.\n\nEvery file is imported as a separate note, the file’s name becomes the note’s title.\nIf the text contents start with Markdown list syntax (e.g. ’- [x] Task1’) it will be converted to a List note.</string>
     <plurals name="imported_notes">
         <item quantity="one">Imported %s Note</item>
         <item quantity="other">Imported %s Notes</item>
@@ -204,6 +205,7 @@
 
     <string name="google_keep">Google Keep</string>
     <string name="evernote">Evernote</string>
+    <string name="plain_text_files">Plain Text Files</string>
 
     <string name="export_backup">Export backup</string>
     <string name="import_backup">Import backup</string>


### PR DESCRIPTION
Closes #103 and closes #62

* Adds import from `Plain Text Files` to `Import Notes from other App`
   - 1 File = 1 Note (Note title is equal to file's name without the extension)
   - Files can have any extension but must contain plain text
   - If the text files start with either Markdown list syntax (e.g. " - [x] XYZ" or Notally's current txt syntax (e.g. "[✓] XYZ") the file is imported as a Task List Note
   - There is no text formatting being imported, if you e.g. import a markdown file its contents are interpreted as plain text (except for the list syntax, as described above)
   - The importer also searches all subfolders recursively for files
* If you select multiple notes its now possible to export them to PDF, JSON, TXT or HTML at once (1 Note = 1 File)

[notallyx_import_export_multiple_txt.webm](https://github.com/user-attachments/assets/6060446d-90e1-4a81-a21d-6a38bec7d6a8)
