### PR TITLE
Save note if any BaseNote fields changed + fix cursor position on undo/redo

### DIFF
--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/note/EditActivity.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/note/EditActivity.kt
@@ -68,7 +68,7 @@ abstract class EditActivity(private val type: Type) : LockedActivity<ActivityEdi
         lifecycleScope.launch(Dispatchers.Main) {
             if (model.isEmpty()) {
                 model.deleteBaseNote()
-            } else if (changeHistory.canUndo()) {
+            } else if (model.isModified()) {
                 saveNote()
             }
             super.finish()
@@ -78,7 +78,7 @@ abstract class EditActivity(private val type: Type) : LockedActivity<ActivityEdi
     override fun onSaveInstanceState(outState: Bundle) {
         super.onSaveInstanceState(outState)
         outState.putLong("id", model.id)
-        if (changeHistory.canUndo()) {
+        if (model.isModified()) {
             lifecycleScope.launch { saveNote() }
         }
     }

--- a/app/src/main/java/com/philkes/notallyx/presentation/view/note/listitem/ListManager.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/view/note/listitem/ListManager.kt
@@ -27,6 +27,7 @@ import com.philkes.notallyx.presentation.viewmodel.preference.NotallyXPreference
 import com.philkes.notallyx.utils.changehistory.ChangeCheckedForAllChange
 import com.philkes.notallyx.utils.changehistory.ChangeHistory
 import com.philkes.notallyx.utils.changehistory.DeleteCheckedChange
+import com.philkes.notallyx.utils.changehistory.EditTextState
 import com.philkes.notallyx.utils.changehistory.ListAddChange
 import com.philkes.notallyx.utils.changehistory.ListCheckedChange
 import com.philkes.notallyx.utils.changehistory.ListDeleteChange
@@ -221,15 +222,15 @@ class ListManager(
         editText: EditText,
         listener: TextWatcher,
         position: Int,
-        textBefore: String,
-        textAfter: String,
+        value: EditTextState,
+        before: EditTextState? = null,
         pushChange: Boolean = true,
     ) {
         val item = items[position]
-        item.body = textAfter
+        item.body = value.text.toString()
         if (pushChange) {
             changeHistory.push(
-                ListEditTextChange(editText, position, textBefore, textAfter, listener, this)
+                ListEditTextChange(editText, position, before!!, value, listener, this)
             )
         }
     }

--- a/app/src/main/java/com/philkes/notallyx/utils/changehistory/EditTextWithHistoryChange.kt
+++ b/app/src/main/java/com/philkes/notallyx/utils/changehistory/EditTextWithHistoryChange.kt
@@ -5,19 +5,19 @@ import com.philkes.notallyx.presentation.view.misc.EditTextWithHistory
 
 class EditTextWithHistoryChange(
     private val editText: EditTextWithHistory,
-    textBefore: Editable,
-    textAfter: Editable,
+    before: EditTextState,
+    after: EditTextState,
     private val updateModel: (newValue: Editable) -> Unit,
-) : ValueChange<Editable>(textAfter, textBefore) {
+) : ValueChange<EditTextState>(after, before) {
 
-    private val cursorPosition = editText.selectionStart
-
-    override fun update(value: Editable, isUndo: Boolean) {
+    override fun update(value: EditTextState, isUndo: Boolean) {
         editText.applyWithoutTextWatcher {
-            text = value
-            updateModel.invoke(value)
+            setText(value.text)
+            updateModel.invoke(value.text)
             requestFocus()
-            setSelection(Math.min(value.length, cursorPosition + (if (isUndo) 1 else 0)))
+            setSelection(value.cursorPos)
         }
     }
 }
+
+data class EditTextState(val text: Editable, val cursorPos: Int)

--- a/app/src/main/java/com/philkes/notallyx/utils/changehistory/ListEditTextChange.kt
+++ b/app/src/main/java/com/philkes/notallyx/utils/changehistory/ListEditTextChange.kt
@@ -7,23 +7,20 @@ import com.philkes.notallyx.presentation.view.note.listitem.ListManager
 open class ListEditTextChange(
     private val editText: EditText,
     position: Int,
-    private val textBefore: String,
-    private val textAfter: String,
+    before: EditTextState,
+    after: EditTextState,
     private val listener: TextWatcher,
     private val listManager: ListManager,
-) : ListPositionValueChange<String>(textAfter, textBefore, position) {
-    private val cursorPosition = editText.selectionStart
+) : ListPositionValueChange<EditTextState>(after, before, position) {
 
-    override fun update(position: Int, value: String, isUndo: Boolean) {
-        listManager.changeText(editText, listener, position, textBefore, value, pushChange = false)
-        editText.removeTextChangedListener(listener)
-        editText.setText(value)
-        editText.requestFocus()
-        editText.setSelection(Math.max(0, cursorPosition - (if (isUndo) 1 else 0)))
-        editText.addTextChangedListener(listener)
-    }
-
-    override fun toString(): String {
-        return "CheckedText at $position from: $textBefore to: $textAfter"
+    override fun update(position: Int, value: EditTextState, isUndo: Boolean) {
+        listManager.changeText(editText, listener, position, value, pushChange = false)
+        editText.apply {
+            removeTextChangedListener(listener)
+            text = value.text
+            requestFocus()
+            setSelection(value.cursorPos)
+            addTextChangedListener(listener)
+        }
     }
 }

--- a/app/src/main/java/com/philkes/notallyx/utils/changehistory/ListPositionValueChange.kt
+++ b/app/src/main/java/com/philkes/notallyx/utils/changehistory/ListPositionValueChange.kt
@@ -1,5 +1,7 @@
 package com.philkes.notallyx.utils.changehistory
 
+import com.philkes.notallyx.presentation.truncate
+
 abstract class ListPositionValueChange<T>(
     internal val newValue: T,
     internal val oldValue: T,
@@ -15,4 +17,8 @@ abstract class ListPositionValueChange<T>(
     }
 
     abstract fun update(position: Int, value: T, isUndo: Boolean)
+
+    override fun toString(): String {
+        return "${javaClass.simpleName} at $position from: ${oldValue.toString().truncate(100)} to: ${newValue.toString().truncate(100)}"
+    }
 }

--- a/app/src/main/java/com/philkes/notallyx/utils/changehistory/ValueChange.kt
+++ b/app/src/main/java/com/philkes/notallyx/utils/changehistory/ValueChange.kt
@@ -1,5 +1,7 @@
 package com.philkes.notallyx.utils.changehistory
 
+import com.philkes.notallyx.presentation.truncate
+
 abstract class ValueChange<T>(protected val newValue: T, protected val oldValue: T) : Change {
 
     override fun redo() {
@@ -11,4 +13,8 @@ abstract class ValueChange<T>(protected val newValue: T, protected val oldValue:
     }
 
     abstract fun update(value: T, isUndo: Boolean)
+
+    override fun toString(): String {
+        return "${javaClass.simpleName} from: ${oldValue.toString().truncate(100)} to: ${newValue.toString().truncate(100)}"
+    }
 }


### PR DESCRIPTION
Closes #124 and closes #125 

* Before, the note was only saved if there are any changes pushed to `ChangeHistory`, now it's saved if any fields of `BaseNote` differ to when the note was initially opened
* Fixed crashes when setting the cursor position on undo/redo action

[notallyx_issues_124.webm](https://github.com/user-attachments/assets/e5a4e430-a799-43b9-af8f-105ac921e705)

