### PR TITLE
Note export file name fixes

### DIFF
--- a/app/src/main/java/com/philkes/notallyx/presentation/UiExtensions.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/UiExtensions.kt
@@ -111,6 +111,10 @@ fun String.truncate(limit: Int): String {
     }
 }
 
+fun String.removeTrailingParentheses(): String {
+    return substringBeforeLast(" (")
+}
+
 /**
  * Adjusts or removes spans based on the selection range.
  *

--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/main/MainActivity.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/main/MainActivity.kt
@@ -349,22 +349,22 @@ class MainActivity : LockedActivity<ActivityMainBinding>() {
                         application,
                         baseNote,
                         DocumentFile.fromFile(application.getExportedPath()),
-                        "Untitled.${mimeType.fileExtension}",
-                        object : PostPDFGenerator.OnResult {
+                        onResult =
+                            object : PostPDFGenerator.OnResult {
 
-                            override fun onSuccess(file: DocumentFile) {
-                                showFileOptionsDialog(file, ExportMimeType.PDF.mimeType)
-                            }
+                                override fun onSuccess(file: DocumentFile) {
+                                    showFileOptionsDialog(file, ExportMimeType.PDF.mimeType)
+                                }
 
-                            override fun onFailure(message: CharSequence?) {
-                                Toast.makeText(
-                                        this@MainActivity,
-                                        R.string.something_went_wrong,
-                                        Toast.LENGTH_SHORT,
-                                    )
-                                    .show()
-                            }
-                        },
+                                override fun onFailure(message: CharSequence?) {
+                                    Toast.makeText(
+                                            this@MainActivity,
+                                            R.string.something_went_wrong,
+                                            Toast.LENGTH_SHORT,
+                                        )
+                                        .show()
+                                }
+                            },
                     )
                 }
                 ExportMimeType.TXT,
@@ -376,7 +376,6 @@ class MainActivity : LockedActivity<ActivityMainBinding>() {
                                 baseNote,
                                 mimeType,
                                 DocumentFile.fromFile(application.getExportedPath()),
-                                "Untitled.${mimeType.fileExtension}",
                             )
                             ?.let { showFileOptionsDialog(it, mimeType.mimeType) }
                     }

--- a/app/src/main/java/com/philkes/notallyx/utils/backup/Export.kt
+++ b/app/src/main/java/com/philkes/notallyx/utils/backup/Export.kt
@@ -223,15 +223,16 @@ object Export {
         app: Application,
         note: BaseNote,
         folder: DocumentFile,
-        fileName: String = "${note.title}.${ExportMimeType.PDF.fileExtension}",
+        fileName: String = note.title,
         onResult: PostPDFGenerator.OnResult? = null,
         progress: MutableLiveData<Progress>? = null,
         counter: AtomicInteger? = null,
         total: Int? = null,
     ) {
-        folder.findFile(fileName)?.delete()
+        val filePath = "$fileName.${ExportMimeType.PDF.fileExtension}"
+        folder.findFile(filePath)?.delete()
         folder.createFile(ExportMimeType.PDF.mimeType, fileName)?.let {
-            val file = DocumentFile.fromFile(File(app.getExportedPath(), fileName))
+            val file = DocumentFile.fromFile(File(app.getExportedPath(), filePath))
             val html = note.toHtml(NotallyXPreferences.getInstance(app).showDateCreated())
             PostPDFGenerator.create(
                 file,
@@ -261,13 +262,13 @@ object Export {
         note: BaseNote,
         exportType: ExportMimeType,
         folder: DocumentFile,
-        fileName: String = "${note.title}.${exportType.fileExtension}",
+        fileName: String = note.title,
         progress: MutableLiveData<Progress>? = null,
         counter: AtomicInteger? = null,
         total: Int? = null,
     ): DocumentFile? {
         return withContext(Dispatchers.IO) {
-            folder.findFile(fileName)?.delete()
+            folder.findFile("$fileName.${exportType.fileExtension}")?.delete()
             val file =
                 folder.createFile(exportType.mimeType, fileName)?.let {
                     app.contentResolver.openOutputStream(it.uri)?.use { stream ->

--- a/app/src/main/java/com/philkes/notallyx/utils/backup/Export.kt
+++ b/app/src/main/java/com/philkes/notallyx/utils/backup/Export.kt
@@ -17,6 +17,7 @@ import com.philkes.notallyx.data.model.FileAttachment
 import com.philkes.notallyx.data.model.toHtml
 import com.philkes.notallyx.data.model.toJson
 import com.philkes.notallyx.data.model.toTxt
+import com.philkes.notallyx.presentation.removeTrailingParentheses
 import com.philkes.notallyx.presentation.view.misc.Progress
 import com.philkes.notallyx.presentation.viewmodel.ExportMimeType
 import com.philkes.notallyx.presentation.viewmodel.preference.BiometricLock
@@ -228,9 +229,22 @@ object Export {
         progress: MutableLiveData<Progress>? = null,
         counter: AtomicInteger? = null,
         total: Int? = null,
+        duplicateFileCount: Int = 1,
     ) {
         val filePath = "$fileName.${ExportMimeType.PDF.fileExtension}"
-        folder.findFile(filePath)?.delete()
+        if (folder.findFile(filePath)?.exists() == true) {
+            return exportPdfFile(
+                app,
+                note,
+                folder,
+                "${fileName.removeTrailingParentheses()} ($duplicateFileCount)",
+                onResult,
+                progress,
+                counter,
+                total,
+                duplicateFileCount + 1,
+            )
+        }
         folder.createFile(ExportMimeType.PDF.mimeType, fileName)?.let {
             val file = DocumentFile.fromFile(File(app.getExportedPath(), filePath))
             val html = note.toHtml(NotallyXPreferences.getInstance(app).showDateCreated())
@@ -266,9 +280,22 @@ object Export {
         progress: MutableLiveData<Progress>? = null,
         counter: AtomicInteger? = null,
         total: Int? = null,
+        duplicateFileCount: Int = 1,
     ): DocumentFile? {
+        if (folder.findFile("$fileName.${exportType.fileExtension}")?.exists() == true) {
+            return exportPlainTextFile(
+                app,
+                note,
+                exportType,
+                folder,
+                "${fileName.removeTrailingParentheses()} ($duplicateFileCount)",
+                progress,
+                counter,
+                total,
+                duplicateFileCount + 1,
+            )
+        }
         return withContext(Dispatchers.IO) {
-            folder.findFile("$fileName.${exportType.fileExtension}")?.delete()
             val file =
                 folder.createFile(exportType.mimeType, fileName)?.let {
                     app.contentResolver.openOutputStream(it.uri)?.use { stream ->


### PR DESCRIPTION
Fixes #143 and fixes #144

* Correctly sets file name to note's title for single note export:

  [notallyx_issues_143.webm](https://github.com/user-attachments/assets/e2f9a3ce-e430-4f47-9640-306055d31a88)

* If multiple notes with the same title are exported they are not overwritten but instead their file name have " (XYZ)" appended: 

  [notallyx_issues_142_duplicate_export_names.webm](https://github.com/user-attachments/assets/d958b2b0-a2ce-4f98-a784-da586f8efc37)

