### PR TITLE
Migrate theme to Material 3

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -42,8 +42,7 @@
 
         <activity
             android:name=".presentation.activity.main.MainActivity"
-            android:exported="true"
-            android:theme="@style/MainActivity">
+            android:exported="true">
 
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/note/EditActivity.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/note/EditActivity.kt
@@ -591,6 +591,7 @@ abstract class EditActivity(private val type: Type) : LockedActivity<ActivityEdi
         val color = Operations.extractColor(model.color, this)
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             window.statusBarColor = color
+            window.navigationBarColor = color
         }
         binding.root.setBackgroundColor(color)
         binding.RecyclerView.setBackgroundColor(color)

--- a/app/src/main/res/drawable/check_box_selector.xml
+++ b/app/src/main/res/drawable/check_box_selector.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+  <item android:state_checked="true" android:drawable="@drawable/check_box_checked" />
+  <item android:drawable="@drawable/check_box_unchecked" />
+</selector>

--- a/app/src/main/res/layout-v26/recycler_label.xml
+++ b/app/src/main/res/layout-v26/recycler_label.xml
@@ -13,7 +13,7 @@
     android:ellipsize="end"
     android:maxLines="1"
     android:padding="16dp"
-    android:textAppearance="?attr/textAppearanceBody1" />
+    android:textAppearance="?attr/textAppearanceBodyLarge" />
 
   <ImageButton
     android:id="@+id/VisibilityButton"

--- a/app/src/main/res/layout-v31/widget_list_child_item.xml
+++ b/app/src/main/res/layout-v31/widget_list_child_item.xml
@@ -9,5 +9,5 @@
     android:paddingTop="8dp"
     android:paddingEnd="0dp"
     android:paddingBottom="8dp"
-    android:textAppearance="?attr/textAppearanceBody2"
+    android:textAppearance="?attr/textAppearanceBodyMedium"
     android:theme="@style/AppTheme" />

--- a/app/src/main/res/layout-v31/widget_list_item.xml
+++ b/app/src/main/res/layout-v31/widget_list_item.xml
@@ -9,5 +9,5 @@
     android:paddingTop="8dp"
     android:paddingEnd="0dp"
     android:paddingBottom="8dp"
-    android:textAppearance="?attr/textAppearanceBody2"
+    android:textAppearance="?attr/textAppearanceBodyMedium"
     android:theme="@style/AppTheme" />

--- a/app/src/main/res/layout/activity_edit.xml
+++ b/app/src/main/res/layout/activity_edit.xml
@@ -50,7 +50,7 @@
                     android:clickable="false"
                     android:gravity="top"
                     android:stateListAnimator="@null"
-                    android:textAppearance="?attr/textAppearanceCaption"
+                    android:textAppearance="?attr/textAppearanceBodySmall"
                     android:visibility="visible"
                     app:chipIcon="@drawable/add_images"
                     app:chipStartPadding="8dp"
@@ -85,7 +85,7 @@
                 android:paddingEnd="24dp"
                 android:paddingBottom="6dp"
                 android:text="@string/date"
-                android:textAppearance="?attr/textAppearanceBody2"
+                android:textAppearance="?attr/textAppearanceBodyMedium"
                 android:textColor="?android:textColorHint" />
 
 
@@ -113,7 +113,7 @@
                 android:paddingStart="24dp"
                 android:paddingTop="16dp"
                 android:paddingEnd="24dp"
-                android:textAppearance="?attr/textAppearanceBody1" />
+                android:textAppearance="?attr/textAppearanceBodyLarge" />
 
             <androidx.recyclerview.widget.RecyclerView
                 android:id="@+id/RecyclerView"

--- a/app/src/main/res/layout/activity_label.xml
+++ b/app/src/main/res/layout/activity_label.xml
@@ -25,6 +25,6 @@
         android:layout_below="@id/Toolbar"
         android:gravity="center"
         android:text="@string/create_new"
-        android:textAppearance="?attr/textAppearanceBody2" />
+        android:textAppearance="?attr/textAppearanceBodyMedium" />
 
 </RelativeLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -29,7 +29,7 @@
                 android:inputType="textFilter"
                 android:paddingTop="10dp"
                 android:paddingBottom="10dp"
-                android:textAppearance="?attr/textAppearanceBody1"
+                android:textAppearance="?attr/textAppearanceBodyLarge"
                 android:visibility="gone" />
 
         </com.google.android.material.appbar.MaterialToolbar>
@@ -60,11 +60,12 @@
             android:layout_marginBottom="16dp"
             android:contentDescription="@string/make_list"
             android:tooltipText="@string/make_list"
-            app:backgroundTint="?attr/alternateFabBackground"
             app:elevation="2dp"
             app:pressedTranslationZ="4dp"
             app:srcCompat="@drawable/checkbox"
-            app:tint="?attr/alternateFabTint" />
+            app:shapeAppearance="@style/PillButton"
+            app:backgroundTint="?attr/secondaryFabBackground"
+            app:tint="?attr/secondaryFabTint" />
 
         <com.google.android.material.floatingactionbutton.FloatingActionButton
             android:id="@+id/TakeNote"
@@ -77,6 +78,8 @@
             android:contentDescription="@string/take_note"
             android:tooltipText="@string/take_note"
             app:shapeAppearanceOverlay="@style/RoundedRectangle"
+            android:backgroundTint="?attr/primaryFabBackground"
+            app:tint="?attr/primaryFabTint"
             app:srcCompat="@drawable/edit" />
 
     </RelativeLayout>
@@ -88,6 +91,7 @@
         android:layout_gravity="start"
         app:headerLayout="@layout/drawer_header"
         app:itemIconTint="@color/navigation_view_item"
-        app:itemTextColor="@color/navigation_view_item" />
+        app:itemTextColor="@color/navigation_view_item"
+        app:drawerLayoutCornerSize="0dp"/>
 
 </androidx.drawerlayout.widget.DrawerLayout>

--- a/app/src/main/res/layout/activity_play_audio.xml
+++ b/app/src/main/res/layout/activity_play_audio.xml
@@ -17,7 +17,7 @@
         android:layout_above="@id/AudioControlView"
         android:layout_below="@id/Toolbar"
         android:gravity="center"
-        android:textAppearance="?attr/textAppearanceBody2" />
+        android:textAppearance="?attr/textAppearanceBodyMedium" />
 
     <com.philkes.notallyx.presentation.view.note.audio.AudioControlView
         android:id="@+id/AudioControlView"
@@ -41,7 +41,7 @@
             android:layout_below="@id/Progress"
             android:layout_alignParentStart="true"
             android:layout_marginStart="8dp"
-            android:textAppearance="?attr/textAppearanceCaption" />
+            android:textAppearance="?attr/textAppearanceBodySmall" />
 
         <TextView
             android:id="@+id/Length"
@@ -50,7 +50,7 @@
             android:layout_below="@id/Progress"
             android:layout_alignParentEnd="true"
             android:layout_marginEnd="8dp"
-            android:textAppearance="?attr/textAppearanceCaption" />
+            android:textAppearance="?attr/textAppearanceBodySmall" />
 
     </com.philkes.notallyx.presentation.view.note.audio.AudioControlView>
 

--- a/app/src/main/res/layout/choice_item_tri_state.xml
+++ b/app/src/main/res/layout/choice_item_tri_state.xml
@@ -23,6 +23,6 @@
     android:layout_height="wrap_content"
     android:layout_weight="1"
     android:layout_gravity="center_vertical"
-    android:textAppearance="?textAppearanceBody2"/>
+    android:textAppearance="?textAppearanceBodyMedium"/>
 
 </LinearLayout>

--- a/app/src/main/res/layout/dialog_input.xml
+++ b/app/src/main/res/layout/dialog_input.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <com.google.android.material.textfield.TextInputLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+    style="@style/Widget.Material3.TextInputLayout.OutlinedBox"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:padding="16dp">

--- a/app/src/main/res/layout/dialog_progress.xml
+++ b/app/src/main/res/layout/dialog_progress.xml
@@ -15,7 +15,7 @@
         android:layout_height="wrap_content"
         android:layout_below="@id/ProgressBar"
         android:paddingTop="16dp"
-        android:textAppearance="?attr/textAppearanceBody2"
+        android:textAppearance="?attr/textAppearanceBodyMedium"
         android:textColor="?attr/colorControlNormal" />
 
 </RelativeLayout>

--- a/app/src/main/res/layout/error.xml
+++ b/app/src/main/res/layout/error.xml
@@ -12,12 +12,12 @@
         android:id="@+id/Name"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:textAppearance="?attr/textAppearanceBody2" />
+        android:textAppearance="?attr/textAppearanceBodyMedium" />
 
     <TextView
         android:id="@+id/Description"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:textAppearance="?attr/textAppearanceCaption" />
+        android:textAppearance="?attr/textAppearanceBodySmall" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/fragment_notes.xml
+++ b/app/src/main/res/layout/fragment_notes.xml
@@ -39,21 +39,21 @@
 
         <com.google.android.material.chip.Chip
             android:id="@+id/Notes"
-            style="@style/Chip"
+            style="@style/TextChip"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@string/notes" />
 
         <com.google.android.material.chip.Chip
             android:id="@+id/Deleted"
-            style="@style/Chip"
+            style="@style/TextChip"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@string/deleted" />
 
         <com.google.android.material.chip.Chip
             android:id="@+id/Archived"
-            style="@style/Chip"
+            style="@style/TextChip"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@string/archived" />

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -192,7 +192,7 @@
           android:id="@+id/VersionText"
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
-          android:textAppearance="?attr/textAppearanceCaption"
+          android:textAppearance="?attr/textAppearanceBodySmall"
           android:gravity="start"
           android:padding="16dp" />
 

--- a/app/src/main/res/layout/label.xml
+++ b/app/src/main/res/layout/label.xml
@@ -5,5 +5,5 @@
     android:includeFontPadding="false"
     android:paddingHorizontal="12dp"
     android:paddingVertical="6dp"
-    android:textAppearance="?attr/textAppearanceBody2"
+    android:textAppearance="?attr/textAppearanceBodyMedium"
     android:textColor="?attr/colorControlNormal" />

--- a/app/src/main/res/layout/preference.xml
+++ b/app/src/main/res/layout/preference.xml
@@ -12,13 +12,13 @@
         android:id="@+id/Title"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:textAppearance="?attr/textAppearanceBody1" />
+        android:textAppearance="?attr/textAppearanceBodyLarge" />
 
     <TextView
         android:id="@+id/Value"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:textAppearance="?attr/textAppearanceBody2"
+        android:textAppearance="?attr/textAppearanceBodyMedium"
         android:textColor="?attr/colorControlNormal" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/preference_boolean_dialog.xml
+++ b/app/src/main/res/layout/preference_boolean_dialog.xml
@@ -23,7 +23,7 @@
     android:id="@+id/Message"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    android:textAppearance="?attr/textAppearanceCaption"
+    android:textAppearance="?attr/textAppearanceBodySmall"
     android:textSize="16sp"
     android:paddingBottom="8dp"
     android:layout_marginTop="12dp"

--- a/app/src/main/res/layout/preference_seekbar.xml
+++ b/app/src/main/res/layout/preference_seekbar.xml
@@ -15,7 +15,7 @@
         android:layout_height="wrap_content"
         android:paddingStart="12dp"
         android:paddingEnd="12dp"
-        android:textAppearance="?attr/textAppearanceBody1" />
+        android:textAppearance="?attr/textAppearanceBodyLarge" />
 
     <com.google.android.material.slider.Slider
         android:id="@+id/Slider"

--- a/app/src/main/res/layout/recycler_audio.xml
+++ b/app/src/main/res/layout/recycler_audio.xml
@@ -15,7 +15,7 @@
         android:layout_centerVertical="true"
         android:layout_marginEnd="8dp"
         android:layout_toStartOf="@id/Length"
-        android:textAppearance="?attr/textAppearanceBody2" />
+        android:textAppearance="?attr/textAppearanceBodyMedium" />
 
     <TextView
         android:id="@+id/Length"
@@ -23,7 +23,7 @@
         android:layout_height="wrap_content"
         android:layout_alignParentEnd="true"
         android:layout_centerVertical="true"
-        android:textAppearance="?attr/textAppearanceBody2"
+        android:textAppearance="?attr/textAppearanceBodyMedium"
         android:textColor="?attr/colorControlNormal" />
 
 </RelativeLayout>

--- a/app/src/main/res/layout/recycler_base_note.xml
+++ b/app/src/main/res/layout/recycler_base_note.xml
@@ -39,7 +39,7 @@
                 android:clickable="false"
                 android:gravity="top"
                 android:stateListAnimator="@null"
-                android:textAppearance="?attr/textAppearanceCaption"
+                android:textAppearance="?attr/textAppearanceBodySmall"
                 android:visibility="visible"
                 app:chipIcon="@drawable/add_images"
                 app:chipStartPadding="8dp"
@@ -58,7 +58,7 @@
             android:layout_height="0dp"
             android:gravity="center"
             android:text="@string/cant_load_image"
-            android:textAppearance="?attr/textAppearanceBody2"
+            android:textAppearance="?attr/textAppearanceBodyMedium"
             app:layout_constraintDimensionRatio="4:3"
             app:layout_constraintTop_toBottomOf="@id/ImageLayout" />
 
@@ -77,7 +77,7 @@
             android:paddingStart="16dp"
             android:paddingEnd="16dp"
             android:paddingBottom="8dp"
-            android:textAppearance="?attr/textAppearanceBody1"
+            android:textAppearance="?attr/textAppearanceBodyLarge"
             android:textColor="?attr/colorOnSurface"
             app:layout_constraintTop_toBottomOf="@id/Space" />
 
@@ -115,7 +115,7 @@
                 app:chipIconSize="10pt"
                 android:stateListAnimator="@null"
                 android:text="@string/cant_load_file"
-                android:textAppearance="?attr/textAppearanceCaption"
+                android:textAppearance="?attr/textAppearanceBodySmall"
                 app:layout_constraintStart_toStartOf="parent"
                 />
 
@@ -129,7 +129,7 @@
                 android:clickable="false"
                 android:stateListAnimator="@null"
                 android:layout_marginStart="6dp"
-                android:textAppearance="?attr/textAppearanceCaption"
+                android:textAppearance="?attr/textAppearanceBodySmall"
                 app:chipStartPadding="8dp"
                 app:textStartPadding="2dp"
                 />

--- a/app/src/main/res/layout/recycler_image.xml
+++ b/app/src/main/res/layout/recycler_image.xml
@@ -14,6 +14,6 @@
         android:layout_height="match_parent"
         android:gravity="center"
         android:text="@string/cant_load_image"
-        android:textAppearance="?attr/textAppearanceBody2" />
+        android:textAppearance="?attr/textAppearanceBodyMedium" />
 
 </FrameLayout>

--- a/app/src/main/res/layout/recycler_label.xml
+++ b/app/src/main/res/layout/recycler_label.xml
@@ -13,7 +13,7 @@
     android:ellipsize="end"
     android:maxLines="1"
     android:padding="16dp"
-    android:textAppearance="?attr/textAppearanceBody1" />
+    android:textAppearance="?attr/textAppearanceBodyLarge" />
 
   <ImageButton
     android:id="@+id/VisibilityButton"

--- a/app/src/main/res/layout/recycler_list_item.xml
+++ b/app/src/main/res/layout/recycler_list_item.xml
@@ -64,7 +64,7 @@
             android:imeOptions="actionNext"
             android:inputType="textMultiLine"
             android:layout_marginEnd="48dp"
-            android:textAppearance="?attr/textAppearanceBody1" />
+            android:textAppearance="?attr/textAppearanceBodyLarge" />
     </RelativeLayout>
     </com.philkes.notallyx.presentation.view.misc.SwipeLayout>
 

--- a/app/src/main/res/layout/recycler_preview_file.xml
+++ b/app/src/main/res/layout/recycler_preview_file.xml
@@ -14,4 +14,4 @@
     app:chipIcon="@drawable/text_file"
     app:chipMinHeight="40dp"
     android:text="@string/cant_load_file"
-    android:textAppearance="?attr/textAppearanceBody2" />
+    android:textAppearance="?attr/textAppearanceBodyMedium" />

--- a/app/src/main/res/layout/recycler_preview_image.xml
+++ b/app/src/main/res/layout/recycler_preview_image.xml
@@ -15,6 +15,6 @@
         android:layout_height="match_parent"
         android:gravity="center"
         android:text="@string/cant_load_image"
-        android:textAppearance="?attr/textAppearanceBody2" />
+        android:textAppearance="?attr/textAppearanceBodyMedium" />
 
 </FrameLayout>

--- a/app/src/main/res/layout/recycler_selectable_label.xml
+++ b/app/src/main/res/layout/recycler_selectable_label.xml
@@ -6,4 +6,4 @@
     android:layout_marginEnd="0dp"
     android:paddingStart="24dp"
     android:paddingEnd="16dp"
-    android:textAppearance="?attr/textAppearanceBody1" />
+    android:textAppearance="?attr/textAppearanceBodyLarge" />

--- a/app/src/main/res/layout/text_input_dialog.xml
+++ b/app/src/main/res/layout/text_input_dialog.xml
@@ -18,7 +18,7 @@
       android:id="@+id/InputTextLayout"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.Dense"
+      style="@style/Widget.Material3.TextInputLayout.OutlinedBox.Dense"
       >
 
         <EditText

--- a/app/src/main/res/layout/text_input_dialog_2.xml
+++ b/app/src/main/res/layout/text_input_dialog_2.xml
@@ -18,7 +18,7 @@
       android:id="@+id/InputTextLayout1"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.Dense">
+      style="@style/Widget.Material3.TextInputLayout.OutlinedBox.Dense">
 
         <EditText
           android:id="@+id/InputText1"
@@ -37,7 +37,7 @@
       android:id="@+id/InputTextLayout2"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.Dense"
+      style="@style/Widget.Material3.TextInputLayout.OutlinedBox.Dense"
       android:layout_marginTop="16dp">
 
         <EditText

--- a/app/src/main/res/layout/widget_list_child_item.xml
+++ b/app/src/main/res/layout/widget_list_child_item.xml
@@ -10,5 +10,5 @@
     android:paddingTop="8dp"
     android:paddingEnd="16dp"
     android:paddingBottom="8dp"
-    android:textAppearance="?attr/textAppearanceBody2"
+    android:textAppearance="?attr/textAppearanceBodyMedium"
     android:theme="@style/AppTheme" />

--- a/app/src/main/res/layout/widget_list_header.xml
+++ b/app/src/main/res/layout/widget_list_header.xml
@@ -21,7 +21,7 @@
             android:layout_height="wrap_content"
             android:fontFamily="sans-serif-medium"
             android:paddingBottom="16dp"
-            android:textAppearance="?attr/textAppearanceBody1"
+            android:textAppearance="?attr/textAppearanceBodyLarge"
             android:textColor="?android:textColorPrimary" />
 
         <TextView

--- a/app/src/main/res/layout/widget_list_item.xml
+++ b/app/src/main/res/layout/widget_list_item.xml
@@ -9,5 +9,5 @@
     android:paddingTop="8dp"
     android:paddingEnd="16dp"
     android:paddingBottom="8dp"
-    android:textAppearance="?attr/textAppearanceBody2"
+    android:textAppearance="?attr/textAppearanceBodyMedium"
     android:theme="@style/AppTheme" />

--- a/app/src/main/res/values-night/styles.xml
+++ b/app/src/main/res/values-night/styles.xml
@@ -3,8 +3,12 @@
 
     <style name="AppTheme" parent="Base.AppTheme">
         <item name="colorPrimary">@color/Blue100</item>
-        <item name="alternateFabTint">?attr/colorOnSecondary</item>
-        <item name="alternateFabBackground">@color/Indigo100</item>
+        <item name="colorPrimaryDark">@color/Blue50</item>
+
+        <item name="primaryFabTint">?attr/colorSurface</item>
+        <item name="primaryFabBackground">@color/Indigo100</item>
+        <item name="secondaryFabTint">?attr/colorSurface</item>
+        <item name="secondaryFabBackground">@color/Indigo100</item>
     </style>
 
 </resources>

--- a/app/src/main/res/values-v23/styles.xml
+++ b/app/src/main/res/values-v23/styles.xml
@@ -3,9 +3,12 @@
 
     <style name="AppTheme" parent="Base.AppTheme">
         <item name="colorPrimary">@color/Blue500</item>
+        <item name="colorPrimaryDark">@color/Black</item>
 
-        <item name="alternateFabTint">@color/Blue500</item>
-        <item name="alternateFabBackground">@color/Blue50</item>
+        <item name="primaryFabTint">@color/Blue50</item>
+        <item name="primaryFabBackground">@color/Blue500</item>
+        <item name="secondaryFabTint">@color/Blue500</item>
+        <item name="secondaryFabBackground">@color/Blue50</item>
 
         <item name="android:windowLightStatusBar">true</item>
     </style>

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <attr name="alternateFabTint" format="reference" />
-    <attr name="alternateFabBackground" format="reference" />
+    <attr name="primaryFabTint" format="reference" />
+    <attr name="primaryFabBackground" format="reference" />
+    <attr name="secondaryFabTint" format="reference" />
+    <attr name="secondaryFabBackground" format="reference" />
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,6 +1,6 @@
 <resources>
 
-    <style name="Base.AppTheme" parent="Theme.MaterialComponents.DayNight.NoActionBar">
+    <style name="Base.AppTheme" parent="Theme.Material3.DayNight.NoActionBar">
         <item name="colorSecondary">?attr/colorPrimary</item>
         <item name="colorOnSecondary">?attr/colorOnPrimary</item>
 
@@ -8,32 +8,36 @@
 
         <item name="windowActionModeOverlay">true</item>
 
-        <item name="textAppearanceButton">@style/TextAppearance.Subtitle2</item>
-        <item name="textAppearanceSubtitle2">@style/TextAppearance.Subtitle2</item>
-        <!-- Menu Items, EditTexts, Dialog Titles -->
-        <item name="textAppearanceSubtitle1">@style/TextAppearance.Subtitle1</item>
-        <item name="textAppearanceHeadline6">@style/TextAppearance.Headline6</item>
-
         <!-- Submenu Title -->
         <item name="textAppearancePopupMenuHeader">@style/TextAppearance.Subtitle2.PopupMenu</item>
 
         <item name="toolbarStyle">@style/Toolbar</item>
         <item name="chipGroupStyle">@style/ChipGroup</item>
+        <item name="chipStyle">@style/IconChip</item>
+        <item name="checkboxStyle">@style/CheckBox</item>
+        <item name="navigationViewStyle">@style/NavigationView</item>
+        <item name="popupMenuBackground">?attr/colorSurface</item>
 
         <item name="materialAlertDialogTheme">@style/AlertDialog</item>
+        <item name="elevationOverlayEnabled">false</item>
+        <item name="android:navigationBarColor">?attr/colorSurface</item>
+
+        <item name="colorSurface">@color/Default</item>
+        <item name="colorSurfaceVariant">@color/Default</item>
+        <item name="android:colorBackground">@color/Default</item>
+        <item name="android:statusBarColor">@color/Default</item>
+
     </style>
 
     <style name="AppTheme" parent="Base.AppTheme">
         <item name="colorPrimaryDark">@color/Black</item>
         <item name="colorPrimary">@color/Blue500</item>
-        <item name="alternateFabTint">@color/Blue500</item>
-        <item name="alternateFabBackground">@color/Blue50</item>
-    </style>
 
-    <style name="MainActivity" parent="AppTheme">
-        <item name="android:statusBarColor">@color/Transparent</item>
+        <item name="primaryFabTint">@color/Blue50</item>
+        <item name="primaryFabBackground">@color/Blue500</item>
+        <item name="secondaryFabTint">@color/Blue500</item>
+        <item name="secondaryFabBackground">@color/Blue50</item>
     </style>
-
 
     <style name="TextAppearance.Headline6.Toolbar">
         <item name="android:textSize">18sp</item>
@@ -55,19 +59,28 @@
         <item name="android:textColor">?attr/colorControlNormal</item>
     </style>
 
-
-    <style name="Toolbar" parent="Widget.MaterialComponents.Toolbar.Surface">
+    <style name="Toolbar" parent="Widget.Material3.Toolbar.Surface">
         <item name="android:elevation">4dp</item>
         <item name="titleTextAppearance">@style/TextAppearance.Headline6.Toolbar</item>
     </style>
 
+    <style name="CheckBox" parent="Widget.Material3.CompoundButton.CheckBox">
+        <item name="buttonTint">?attr/colorPrimaryDark</item>
+        <item name="buttonCompat">@drawable/check_box_selector</item>
+    </style>
+
+    <style name="NavigationView" parent="Widget.Material3.NavigationView">
+        <item name="android:background">?attr/colorSurface</item>
+    </style>
 
     <style name="Preview" parent="Widget.AppCompat.TextView">
+        <item name="android:stateListAnimator">@null</item>
         <item name="android:paddingBottom">16dp</item>
         <item name="android:maxLines">1</item>
         <item name="android:ellipsize">end</item>
         <item name="android:textColor">?attr/colorControlNormal</item>
-        <item name="android:textAppearance">?attr/textAppearanceBody2</item>
+        <item name="android:textAppearance">?attr/textAppearanceBodyMedium</item>
+
     </style>
 
     <style name="Preview.ListItem">
@@ -82,38 +95,41 @@
     </style>
 
 
-    <style name="ChipGroup" parent="Widget.MaterialComponents.ChipGroup">
+    <style name="ChipGroup" parent="Widget.Material3.ChipGroup">
         <item name="chipSpacingVertical">8dp</item>
     </style>
 
 
-    <style name="Chip" parent="Widget.MaterialComponents.Chip.Choice">
+    <style name="TextChip" parent="Widget.MaterialComponents.Chip.Choice">
         <item name="android:stateListAnimator">@null</item>
-        <item name="android:textColor">@color/navigation_view_item</item>
         <item name="chipStrokeWidth">1dp</item>
         <item name="chipStrokeColor">@color/chip_stroke</item>
         <item name="chipBackgroundColor">@color/chip_background</item>
         <item name="ensureMinTouchTargetSize">false</item>
     </style>
 
+    <style name="IconChip" parent="Widget.Material3.Chip.Assist">
+        <item name="android:textColor">?attr/colorControlNormal</item>
+    </style>
 
-    <style name="AlertDialog.Title" parent="MaterialAlertDialog.MaterialComponents.Title.Text">
+
+    <style name="AlertDialog.Title" parent="MaterialAlertDialog.Material3.Title.Text">
         <item name="android:fontFamily">sans-serif-medium</item>
     </style>
 
 
-    <style name="AlertDialog" parent="ThemeOverlay.MaterialComponents.MaterialAlertDialog">
+    <style name="AlertDialog" parent="ThemeOverlay.Material3.MaterialAlertDialog">
         <item name="materialAlertDialogTitleTextStyle">@style/AlertDialog.Title</item>
     </style>
 
-    <style name="Colorless" parent="ThemeOverlay.MaterialComponents">
+    <style name="Colorless" parent="ThemeOverlay.Material3">
         <item name="colorSecondary">?attr/colorOnSurface</item>
     </style>
 
 
     <style name="Preference" parent="TextView.Clickable">
         <item name="android:padding">16dp</item>
-        <item name="android:textAppearance">?attr/textAppearanceBody1</item>
+        <item name="android:textAppearance">?attr/textAppearanceBodyLarge</item>
     </style>
 
     <style name="PreferenceHeader" parent="Widget.AppCompat.TextView">
@@ -126,7 +142,7 @@
     </style>
 
 
-    <style name="RoundedRectangle" parent="ShapeAppearance.MaterialComponents.SmallComponent">
+    <style name="RoundedRectangle" parent="ShapeAppearance.Material3.SmallComponent">
         <item name="cornerSize">16dp</item>
     </style>
 
@@ -137,7 +153,7 @@
         <item name="android:textAppearance">@style/TextAppearance.MaterialComponents.Body2</item>
     </style>
 
-    <style name="PillButton" parent="Widget.MaterialComponents.Button.UnelevatedButton">
+    <style name="PillButton" parent="Widget.Material3.Button.UnelevatedButton">
         <item name="android:layout_width">112dp</item>
         <item name="android:insetTop">0dp</item>
         <item name="android:insetBottom">0dp</item>


### PR DESCRIPTION
Closes #104

Migrates the app's theme to Material3

<div style="display: flex; justify-content: space-between; width: 100%;">
<img src="https://github.com/user-attachments/assets/061dcb0c-c479-4dea-97e9-6af2a7642314" width="30%" />
<img src="https://github.com/user-attachments/assets/f83843ef-4917-4067-9c28-b02cbdd1e21e" width="30%" />
<img src="https://github.com/user-attachments/assets/d57d9941-30ef-4123-b6b5-bb26e6bbe1ab" width="30%" />
</div>

Most noticeable theme changes:
- Top App Bar does not draw a shadow anymore
- Cards border radius is increased
- File/Image Labels are now outlined
- Setting Sliders are much bigger in Material3
- Navigation SideDrawer with rounded highlights, different item separators
- Input fields in dialogs might look slightly different

For more info, see [Migrating from M2 to M3](https://m3.material.io/blog/migrating-material-3)