### PR TITLE
Parse list syntax on paste in list note

### DIFF
--- a/app/src/main/java/com/philkes/notallyx/data/imports/txt/PlainTextExtensions.kt
+++ b/app/src/main/java/com/philkes/notallyx/data/imports/txt/PlainTextExtensions.kt
@@ -1,0 +1,42 @@
+package com.philkes.notallyx.data.imports.txt
+
+import com.philkes.notallyx.data.model.ListItem
+
+fun CharSequence.extractListItems(regex: Regex): List<ListItem> {
+    return regex
+        .findAll(this)
+        .mapIndexedNotNull { idx, matchResult ->
+            val isChild = matchResult.groupValues[1] != ""
+            val isChecked = matchResult.groupValues[2] != ""
+            val itemText = matchResult.groupValues[3]
+            if (itemText.isNotBlank()) {
+                ListItem(itemText.trimStart(), isChecked, isChild, idx, mutableListOf())
+            } else null
+        }
+        .toList()
+}
+
+fun CharSequence.findListSyntaxRegex(
+    checkContains: Boolean = false,
+    plainNewLineAllowed: Boolean = false,
+): Regex? {
+    val checkCallback: (String) -> Boolean =
+        if (checkContains) {
+            { string -> startsWith(string) || contains(string, ignoreCase = true) }
+        } else {
+            { string -> startsWith(string) }
+        }
+    if (checkCallback("- [ ]") || checkCallback("- [x]")) {
+        return "\n?(\\s*)-? ?\\[? ?([xX]?)\\]?(.*)".toRegex()
+    }
+    if (checkCallback("[ ]") || checkCallback("[✓]")) {
+        return "\n?(\\s*)\\[? ?(✓?)\\]?(.*)".toRegex()
+    }
+    if (checkCallback("-") || checkCallback("*")) {
+        return "\n?(\\s*)[-*]?\\s*()(.*)".toRegex()
+    }
+    if (plainNewLineAllowed && contains("\n")) {
+        return "\n?(\\s*)()(.*)".toRegex()
+    }
+    return null
+}

--- a/app/src/main/java/com/philkes/notallyx/data/imports/txt/PlainTextImporter.kt
+++ b/app/src/main/java/com/philkes/notallyx/data/imports/txt/PlainTextImporter.kt
@@ -72,26 +72,4 @@ class PlainTextImporter : ExternalImporter {
 
         return Pair(notes, null)
     }
-
-    fun String.extractListItems(regex: Regex): List<ListItem> {
-        return regex
-            .findAll(this)
-            .mapIndexed { idx, matchResult ->
-                val isChild = matchResult.groupValues[1] != ""
-                val isChecked = matchResult.groupValues[2] != ""
-                val itemText = matchResult.groupValues[3]
-                ListItem(itemText.trimStart(), isChecked, isChild, idx, mutableListOf())
-            }
-            .toList()
-    }
-
-    fun String.findListSyntaxRegex(): Regex? {
-        if (startsWith("[ ]") || startsWith("[✓]")) {
-            return "\n?(\\s*)\\[ ?(✓?)\\](.*)".toRegex()
-        }
-        if (startsWith("- [ ]") || startsWith("- [x]", ignoreCase = true)) {
-            return "\n?(\\s*)- \\[ ?([xX]?)\\](.*)".toRegex()
-        }
-        return null
-    }
 }

--- a/app/src/main/java/com/philkes/notallyx/presentation/view/misc/EditTextAutoClearFocus.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/view/misc/EditTextAutoClearFocus.kt
@@ -3,10 +3,9 @@ package com.philkes.notallyx.presentation.view.misc
 import android.content.Context
 import android.util.AttributeSet
 import android.view.KeyEvent
-import androidx.appcompat.widget.AppCompatEditText
 
 class EditTextAutoClearFocus(context: Context, attributeSet: AttributeSet) :
-    AppCompatEditText(context, attributeSet) {
+    EditTextWithWatcher(context, attributeSet) {
 
     override fun onKeyPreIme(keyCode: Int, event: KeyEvent): Boolean {
         if (keyCode == KeyEvent.KEYCODE_BACK && event.action == KeyEvent.ACTION_UP) {

--- a/app/src/main/java/com/philkes/notallyx/presentation/view/misc/EditTextWithHistory.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/view/misc/EditTextWithHistory.kt
@@ -3,7 +3,6 @@ package com.philkes.notallyx.presentation.view.misc
 import android.content.Context
 import android.text.Editable
 import android.text.Spanned
-import android.text.TextWatcher
 import android.text.style.CharacterStyle
 import android.text.style.URLSpan
 import android.util.AttributeSet
@@ -22,12 +21,11 @@ import com.philkes.notallyx.utils.changehistory.EditTextWithHistoryChange
  * *
  */
 class EditTextWithHistory(context: Context, attrs: AttributeSet) :
-    AppCompatEditText(context, attrs) {
+    EditTextWithWatcher(context, attrs) {
 
     var isActionModeOn = false
     private var changeHistory: ChangeHistory? = null
     private var updateModel: ((text: Editable) -> Unit)? = null
-    private var textWatcher: TextWatcher? = null
 
     /**
      * If this is called every future text or span change is pushed to [changeHistory].
@@ -63,37 +61,6 @@ class EditTextWithHistory(context: Context, attrs: AttributeSet) :
         if (!isActionModeOn) {
             super.onWindowFocusChanged(hasWindowFocus)
         }
-    }
-
-    @Deprecated(
-        "You should not access text Editable directly, use other member functions to edit/read text properties.",
-        replaceWith = ReplaceWith("changeText/applyWithoutTextWatcher/..."),
-    )
-    override fun getText(): Editable? {
-        return super.getText()
-    }
-
-    fun getTextClone(): Editable {
-        return super.getText()!!.clone()
-    }
-
-    override fun setText(text: CharSequence?, type: BufferType?) {
-        applyWithoutTextWatcher { super.setText(text, type) }
-    }
-
-    fun setText(text: Editable) {
-        super.setText(text, BufferType.EDITABLE)
-    }
-
-    fun applyWithoutTextWatcher(
-        callback: EditTextWithHistory.() -> Unit
-    ): Pair<Editable, Editable> {
-        val textBefore = super.getText()!!.clone()
-        val editTextWatcher = textWatcher
-        editTextWatcher?.let { removeTextChangedListener(it) }
-        callback()
-        editTextWatcher?.let { addTextChangedListener(it) }
-        return Pair(textBefore, super.getText()!!.clone())
     }
 
     fun getSpanRange(span: CharacterStyle): Pair<Int, Int> {
@@ -191,15 +158,5 @@ class EditTextWithHistory(context: Context, attrs: AttributeSet) :
                 updateModel?.invoke(text.clone())
             }
         )
-    }
-
-    /**
-     * Can be used to change `text` without triggering the [TextWatcher], which would push a
-     * [EditTextWithHistoryChange] to [changeHistory].
-     *
-     * @return Clones of `text` before the changes and `text` after. *
-     */
-    fun changeText(callback: (text: Editable) -> Unit): Pair<Editable, Editable> {
-        return applyWithoutTextWatcher { callback(super.getText()!!) }
     }
 }

--- a/app/src/main/java/com/philkes/notallyx/presentation/view/misc/EditTextWithWatcher.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/view/misc/EditTextWithWatcher.kt
@@ -1,0 +1,48 @@
+package com.philkes.notallyx.presentation.view.misc
+
+import android.content.Context
+import android.text.Editable
+import android.text.TextWatcher
+import android.util.AttributeSet
+import androidx.appcompat.widget.AppCompatEditText
+import com.philkes.notallyx.presentation.clone
+
+open class EditTextWithWatcher(context: Context, attrs: AttributeSet) :
+    AppCompatEditText(context, attrs) {
+    var textWatcher: TextWatcher? = null
+
+    override fun setText(text: CharSequence?, type: BufferType?) {
+        applyWithoutTextWatcher { super.setText(text, type) }
+    }
+
+    fun setText(text: Editable) {
+        super.setText(text, BufferType.EDITABLE)
+    }
+
+    @Deprecated(
+        "You should not access text Editable directly, use other member functions to edit/read text properties.",
+        replaceWith = ReplaceWith("changeText/applyWithoutTextWatcher/..."),
+    )
+    override fun getText(): Editable? {
+        return super.getText()
+    }
+
+    fun getTextClone(): Editable {
+        return super.getText()!!.clone()
+    }
+
+    fun applyWithoutTextWatcher(
+        callback: EditTextWithWatcher.() -> Unit
+    ): Pair<Editable, Editable> {
+        val textBefore = super.getText()!!.clone()
+        val editTextWatcher = textWatcher
+        editTextWatcher?.let { removeTextChangedListener(it) }
+        callback()
+        editTextWatcher?.let { addTextChangedListener(it) }
+        return Pair(textBefore, super.getText()!!.clone())
+    }
+
+    fun changeText(callback: (text: Editable) -> Unit): Pair<Editable, Editable> {
+        return applyWithoutTextWatcher { callback(super.getText()!!) }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -190,7 +190,7 @@
     <string name="help">Help</string>
     <string name="google_keep_help">In order to import your Notes from Google Keep you must download your Google Takeout ZIP file. Click Help to get more information.\n\nIf you already have a Takeout ZIP file, click Import and choose the ZIP file.</string>
     <string name="evernote_help">In order to import your Notes from Evernote you must export your Evernote Notebook as ENEX. Click Help to get more information.\n\nIf you already have a ENEX file, click Import and choose it.</string>
-    <string name="plain_text_files_help">In order to import your Notes from plain text files, click Import and choose the folder containing the text files.\n\nEvery file is imported as a separate note, the file’s name becomes the note’s title.\nIf the text contents start with Markdown list syntax (e.g. ’- [x] Task1’) it will be converted to a List note.</string>
+    <string name="plain_text_files_help">In order to import your Notes from plain text files, click Import and choose the folder containing the text files.  Every file is imported as a separate note, the file’s name becomes the note’s title. If the text contents start with list syntax (e.g. Markdown ’- [x]’, NotallyX syntax ’[✓]’, or ’*’, ’-’) it will be converted to a List note.</string>
     <plurals name="imported_notes">
         <item quantity="one">Imported %s Note</item>
         <item quantity="other">Imported %s Notes</item>

--- a/app/src/test/kotlin/com/philkes/notallyx/data/imports/txt/PlainTextExtensionsTest.kt
+++ b/app/src/test/kotlin/com/philkes/notallyx/data/imports/txt/PlainTextExtensionsTest.kt
@@ -1,0 +1,128 @@
+package com.philkes.notallyx.data.imports.txt
+
+import junit.framework.TestCase.assertNotNull
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.groups.Tuple
+import org.junit.Test
+
+class PlainTextExtensionsTest {
+
+    @Test
+    fun `extractListItems NotallyX syntax`() {
+        val text =
+            """
+        [ ] 🧪 10:00 AM - Chemistry Lab
+        [✓] 📖 1:00 PM - History Lecture
+        [✓] 🏋️ 5:00 PM - Gym Session
+        """
+                .trimIndent()
+
+        val syntax = text.findListSyntaxRegex()
+        assertNotNull(syntax)
+        val items = text.extractListItems(syntax!!)
+        assertThat(items)
+            .hasSize(3)
+            .extracting("body", "checked")
+            .containsExactly(
+                Tuple("🧪 10:00 AM - Chemistry Lab", false),
+                Tuple("📖 1:00 PM - History Lecture", true),
+                Tuple("🏋️ 5:00 PM - Gym Session", true),
+            )
+    }
+
+    @Test
+    fun `extractListItems Markdown syntax`() {
+        val text =
+            """
+        - [ ] 🧪 10:00 AM - Chemistry Lab
+        - [x] 📖 1:00 PM - History Lecture
+        - [X] 🏋️ 5:00 PM - Gym Session
+        """
+                .trimIndent()
+
+        val syntax = text.findListSyntaxRegex()
+        assertNotNull(syntax)
+        val items = text.extractListItems(syntax!!)
+        assertThat(items)
+            .hasSize(3)
+            .extracting("body", "checked")
+            .containsExactly(
+                Tuple("🧪 10:00 AM - Chemistry Lab", false),
+                Tuple("📖 1:00 PM - History Lecture", true),
+                Tuple("🏋️ 5:00 PM - Gym Session", true),
+            )
+    }
+
+    @Test
+    fun `extractListItems isChild indentation`() {
+        val text =
+            """
+          - [ ] Monday:
+             - [ ] 🧪 10:00 AM - Chemistry Lab
+             - [x] 📖 1:00 PM - History Lecture
+             - [X] 🏋️ 5:00 PM - Gym Session
+        """
+                .trimIndent()
+
+        val syntax = text.findListSyntaxRegex()
+        assertNotNull(syntax)
+        val items = text.extractListItems(syntax!!)
+        assertThat(items)
+            .hasSize(4)
+            .extracting("body", "isChild")
+            .containsExactly(
+                Tuple("Monday:", false),
+                Tuple("🧪 10:00 AM - Chemistry Lab", true),
+                Tuple("📖 1:00 PM - History Lecture", true),
+                Tuple("🏋️ 5:00 PM - Gym Session", true),
+            )
+    }
+
+    @Test
+    fun `extractListItems with checkContains`() {
+        val text =
+            """
+        Monday:
+        - 🧪 10:00 AM - Chemistry Lab
+        - 📖 1:00 PM - History Lecture
+        - 🏋️ 5:00 PM - Gym Session
+        """
+                .trimIndent()
+
+        val syntax = text.findListSyntaxRegex(checkContains = true)
+        assertNotNull(syntax)
+        val items = text.extractListItems(syntax!!)
+        assertThat(items)
+            .hasSize(4)
+            .extracting("body")
+            .containsExactly(
+                "Monday:",
+                "🧪 10:00 AM - Chemistry Lab",
+                "📖 1:00 PM - History Lecture",
+                "🏋️ 5:00 PM - Gym Session",
+            )
+    }
+
+    @Test
+    fun `extractListItems with plainNewLineAllowed`() {
+        val text =
+            """
+        🧪 10:00 AM - Chemistry Lab
+        📖 1:00 PM - History Lecture
+        🏋️ 5:00 PM - Gym Session
+        """
+                .trimIndent()
+
+        val syntax = text.findListSyntaxRegex(plainNewLineAllowed = true)
+        assertNotNull(syntax)
+        val items = text.extractListItems(syntax!!)
+        assertThat(items)
+            .hasSize(3)
+            .extracting("body")
+            .containsExactly(
+                "🧪 10:00 AM - Chemistry Lab",
+                "📖 1:00 PM - History Lecture",
+                "🏋️ 5:00 PM - Gym Session",
+            )
+    }
+}


### PR DESCRIPTION
Closes #150 

When pasting list-like text into a list note its automatically parsed into separate list items.
You can see all supported list syntaxes here:

[notallyx_issues_150_paste_list.webm](https://github.com/user-attachments/assets/88fa1af2-4d4b-4af2-a66e-3ffebbe69016)

For Markdown and NotallyX syntax it also parses the checkbox value.
If any items in the original text are indented they are parsed and indented as child list items

All the described syntaxes are also supported when importing text files.

