### PR TITLE
Fix delete list item on DEL key pressed

### DIFF
--- a/app/src/main/java/com/philkes/notallyx/presentation/view/note/listitem/ListItemVH.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/view/note/listitem/ListItemVH.kt
@@ -107,7 +107,11 @@ class ListItemVH(
             isEnabled = !item.checked
             addTextChangedListener(editTextWatcher)
             setOnKeyListener { _, keyCode, event ->
-                if (event.action == KeyEvent.ACTION_UP && keyCode == KeyEvent.KEYCODE_DEL) {
+                if (
+                    event.action == KeyEvent.ACTION_DOWN &&
+                        keyCode == KeyEvent.KEYCODE_DEL &&
+                        item.body.isEmpty()
+                ) {
                     // TODO: when there are multiple checked items above it does not jump to the
                     // last
                     // unchecked item but always re-adds a new item


### PR DESCRIPTION
Fixes #142 

Ensures that the list item is only removed if the text is empty and backspace/delete key is pressed.
Tested with chinese input keyboard:

[notallyx_issues_142_chinese_del.webm](https://github.com/user-attachments/assets/9cba947b-ac8d-48da-bbea-05d2fbac23be)
