### PR TITLE
Show edit link dialog when note without title is linked

### DIFF
--- a/app/src/main/java/com/philkes/notallyx/presentation/UiExtensions.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/UiExtensions.kt
@@ -473,13 +473,17 @@ fun Activity.showColorSelectDialog(callback: (selectedColor: Color) -> Unit) {
     }
 }
 
-fun MaterialAlertDialogBuilder.showAndFocus(view: View): AlertDialog {
-    val dialog = show()
-    view.requestFocus()
-    if (view is EditText) {
-        dialog.window?.setSoftInputMode(SOFT_INPUT_STATE_VISIBLE)
+fun MaterialAlertDialogBuilder.showAndFocus(view: View, selectAll: Boolean = false): AlertDialog {
+    return create().apply {
+        view.requestFocus()
+        if (view is EditText) {
+            if (selectAll) {
+                view.selectAll()
+            }
+            window?.setSoftInputMode(SOFT_INPUT_STATE_VISIBLE)
+        }
+        show()
     }
-    return dialog
 }
 
 fun Context.getQuantityString(id: Int, quantity: Int, vararg formatArgs: Any): String {

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -73,7 +73,7 @@
     <string name="audio_recordings">Sprachnotizen</string>
     <string name="drag_handle">Ziehgriff</string>
     <string name="bold">Fett</string>
-    <string name="link">Link erstellen</string>
+    <string name="link">Link</string>
     <string name="remove_link">Link entfernen</string>
     <string name="italic">Kursiv</string>
     <string name="strikethrough">Durchstreichen</string>


### PR DESCRIPTION
Closes #166 

* If the user tries to link a note that has no title, a dialog to enter a custom display-text for the link is shown:

[notallyx_issues_166.webm](https://github.com/user-attachments/assets/b92abeca-5476-4f7e-a068-3f06e6f23b49)

* You can also change the display-text of the note-link afterwards: 

[notallyx_issues_166_2.webm](https://github.com/user-attachments/assets/bb6dc89b-0375-4f07-ae4a-e1627d4ab929)
