### PR TITLE
Add clickable spans when text containing urls is pasted

### DIFF
--- a/app/src/main/java/com/philkes/notallyx/data/model/ModelExtensions.kt
+++ b/app/src/main/java/com/philkes/notallyx/data/model/ModelExtensions.kt
@@ -13,6 +13,17 @@ fun CharSequence?.isWebUrl(): Boolean {
     return this?.let { Patterns.WEB_URL.matcher(this).matches() } ?: false
 }
 
+fun CharSequence?.findWebUrls(): Collection<Pair<Int, Int>> {
+    return this?.let {
+        val matcher = Patterns.WEB_URL.matcher(this)
+        val matches = mutableListOf<Pair<Int, Int>>()
+        while (matcher.find()) {
+            matches.add(Pair(matcher.start(), matcher.end()))
+        }
+        matches
+    } ?: listOf()
+}
+
 private const val NOTE_URL_PREFIX = "note://"
 private val NOTE_URL_POSTFIX_NOTE = "/${Type.NOTE.name}"
 private val NOTE_URL_POSTFIX_LIST = "/${Type.LIST.name}"

--- a/app/src/main/java/com/philkes/notallyx/presentation/view/misc/StylableEditTextWithHistory.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/view/misc/StylableEditTextWithHistory.kt
@@ -17,6 +17,7 @@ import androidx.appcompat.widget.AppCompatEditText
 import androidx.core.content.ContextCompat
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.philkes.notallyx.R
+import com.philkes.notallyx.data.model.findWebUrls
 import com.philkes.notallyx.data.model.isNoteUrl
 import com.philkes.notallyx.data.model.isWebUrl
 import com.philkes.notallyx.databinding.TextInputDialog2Binding
@@ -54,15 +55,17 @@ class StylableEditTextWithHistory(context: Context, attrs: AttributeSet) :
                 changeHistory,
                 { text, start, count ->
                     clearHighlights()
-                    val changedText = text.substring(start, start + count)
-                    if (changedText.isWebUrl() || changedText.isNoteUrl()) {
-                        super.getText()
-                            ?.setSpan(
-                                URLSpan(changedText),
-                                start,
-                                start + count,
-                                Spanned.SPAN_EXCLUSIVE_EXCLUSIVE,
-                            )
+                    if (count > 1) {
+                        val changedText = text.substring(start, start + count)
+                        changedText.findWebUrls().forEach { (urlStart, urlEnd) ->
+                            super.getText()
+                                ?.setSpan(
+                                    URLSpan(changedText.substring(urlStart, urlEnd)),
+                                    start + urlStart,
+                                    start + urlEnd,
+                                    Spanned.SPAN_EXCLUSIVE_EXCLUSIVE,
+                                )
+                        }
                     }
                 },
             ) { text: Editable ->


### PR DESCRIPTION
Closes #157 

When pasting a text containing more than just a url, links are now correctly converted to clickable spans:

[notallyx_issues_157.webm](https://github.com/user-attachments/assets/35be97eb-1429-4f1a-89ba-87d27da35c96)
