### PR TITLE
Fix settings Slider debounce

### DIFF
--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/main/fragment/SettingsFragment.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/main/fragment/SettingsFragment.kt
@@ -22,6 +22,7 @@ import androidx.documentfile.provider.DocumentFile
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import com.google.android.material.slider.Slider
 import com.google.android.material.textfield.TextInputLayout.END_ICON_PASSWORD_TOGGLE
 import com.philkes.notallyx.NotallyXApplication
 import com.philkes.notallyx.R
@@ -782,7 +783,16 @@ class SettingsFragment : Fragment() {
             valueTo = max.toFloat()
             valueFrom = min.toFloat()
             this@apply.value = value.toFloat()
-            addOnChangeListener { _, value, _ -> onChange(value.toInt()) }
+            clearOnSliderTouchListeners()
+            addOnSliderTouchListener(
+                object : Slider.OnSliderTouchListener {
+                    override fun onStartTrackingTouch(slider: Slider) {}
+
+                    override fun onStopTrackingTouch(slider: Slider) {
+                        onChange(slider.value.toInt())
+                    }
+                }
+            )
             contentDescription = getString(titleResId)
         }
     }


### PR DESCRIPTION
Fixes #192 

Before: While the user is dragging a slider in the settings the onChange events were constantly triggered
After: The onChange event is only triggered once the user stops dragging the slider