### PR TITLE
Fix bottom appbar cutoff + add setting to hide labels in notes overview

### DIFF
--- a/app/src/main/java/com/philkes/notallyx/presentation/UiExtensions.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/UiExtensions.kt
@@ -33,6 +33,7 @@ import android.view.inputmethod.InputMethodManager
 import android.widget.CompoundButton
 import android.widget.EditText
 import android.widget.ImageButton
+import android.widget.ImageView
 import android.widget.LinearLayout
 import android.widget.RadioButton
 import android.widget.RadioGroup
@@ -46,6 +47,7 @@ import androidx.core.content.FileProvider
 import androidx.core.graphics.drawable.DrawableCompat
 import androidx.core.view.marginBottom
 import androidx.core.view.marginTop
+import androidx.core.view.setPadding
 import androidx.documentfile.provider.DocumentFile
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.LifecycleOwner
@@ -222,12 +224,15 @@ fun ViewGroup.addIconButton(
             contentDescription = context.getString(title)
             setBackgroundResource(R.color.Transparent)
             setOnClickListener(onClick)
+            scaleType = ImageView.ScaleType.FIT_CENTER
+            adjustViewBounds = true
             layoutParams =
                 LinearLayout.LayoutParams(
                         LinearLayout.LayoutParams.WRAP_CONTENT,
-                        LinearLayout.LayoutParams.WRAP_CONTENT,
+                        LinearLayout.LayoutParams.MATCH_PARENT,
                     )
                     .apply { setMargins(marginStart.dp(context), marginTop, 0, marginBottom) }
+            setPadding(8.dp(context))
         }
     addView(view)
     return view

--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/main/fragment/NotallyFragment.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/main/fragment/NotallyFragment.kt
@@ -33,6 +33,7 @@ import com.philkes.notallyx.presentation.getQuantityString
 import com.philkes.notallyx.presentation.movedToResId
 import com.philkes.notallyx.presentation.view.Constants
 import com.philkes.notallyx.presentation.view.main.BaseNoteAdapter
+import com.philkes.notallyx.presentation.view.main.BaseNoteVHPreferences
 import com.philkes.notallyx.presentation.view.misc.ItemListener
 import com.philkes.notallyx.presentation.viewmodel.BaseNoteModel
 import com.philkes.notallyx.presentation.viewmodel.preference.NotesView
@@ -162,10 +163,13 @@ abstract class NotallyFragment : Fragment(), ItemListener {
                     model.actionMode.selectedIds,
                     dateFormat.value,
                     notesSorting.value,
-                    textSize.value,
-                    maxItems.value,
-                    maxLines.value,
-                    maxTitle.value,
+                    BaseNoteVHPreferences(
+                        textSize.value,
+                        maxItems.value,
+                        maxLines.value,
+                        maxTitle.value,
+                        labelsHiddenInOverview.value,
+                    ),
                     model.imageRoot,
                     this@NotallyFragment,
                 )

--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/main/fragment/settings/PreferenceBindingExtensions.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/main/fragment/settings/PreferenceBindingExtensions.kt
@@ -179,9 +179,8 @@ fun PreferenceBinding.setup(
     value: Boolean,
     context: Context,
     layoutInflater: LayoutInflater,
-    model: BaseNoteModel,
     messageResId: Int? = null,
-    onSave: ((newValue: Boolean) -> Unit)?,
+    onSave: (newValue: Boolean) -> Unit,
 ) {
     Title.setText(preference.titleResId!!)
 
@@ -205,13 +204,13 @@ fun PreferenceBinding.setup(
             EnabledButton.setOnClickListener {
                 dialog.cancel()
                 if (!value) {
-                    onSave?.invoke(true) ?: model.savePreference(preference, true)
+                    onSave.invoke(true)
                 }
             }
             DisabledButton.setOnClickListener {
                 dialog.cancel()
                 if (value) {
-                    onSave?.invoke(false) ?: model.savePreference(preference, false)
+                    onSave.invoke(false)
                 }
             }
         }

--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/main/fragment/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/main/fragment/settings/SettingsFragment.kt
@@ -233,6 +233,17 @@ class SettingsFragment : Fragment() {
             MaxLines.setup(maxLines, requireContext()) { newValue ->
                 model.savePreference(maxLines, newValue)
             }
+            labelsHiddenInOverview.observe(viewLifecycleOwner) { value ->
+                binding.LabelsHiddenInOverview.setup(
+                    labelsHiddenInOverview,
+                    value,
+                    requireContext(),
+                    layoutInflater,
+                    R.string.labels_hidden_in_overview,
+                ) { enabled ->
+                    model.savePreference(labelsHiddenInOverview, enabled)
+                }
+            }
         }
     }
 
@@ -274,7 +285,6 @@ class SettingsFragment : Fragment() {
                 value,
                 requireContext(),
                 layoutInflater,
-                model,
                 R.string.external_data_message,
             ) { enabled ->
                 if (enabled) {

--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/note/PickNoteActivity.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/note/PickNoteActivity.kt
@@ -13,6 +13,7 @@ import com.philkes.notallyx.data.model.Header
 import com.philkes.notallyx.databinding.ActivityPickNoteBinding
 import com.philkes.notallyx.presentation.activity.LockedActivity
 import com.philkes.notallyx.presentation.view.main.BaseNoteAdapter
+import com.philkes.notallyx.presentation.view.main.BaseNoteVHPreferences
 import com.philkes.notallyx.presentation.view.misc.ItemListener
 import com.philkes.notallyx.presentation.viewmodel.BaseNoteModel
 import com.philkes.notallyx.presentation.viewmodel.preference.NotallyXPreferences
@@ -45,10 +46,13 @@ open class PickNoteActivity : LockedActivity<ActivityPickNoteBinding>(), ItemLis
                     Collections.emptySet(),
                     dateFormat.value,
                     notesSorting.value,
-                    textSize.value,
-                    maxItems.value,
-                    maxLines.value,
-                    maxTitle.value,
+                    BaseNoteVHPreferences(
+                        textSize.value,
+                        maxItems.value,
+                        maxLines.value,
+                        maxTitle.value,
+                        labelsHiddenInOverview.value,
+                    ),
                     application.getExternalImagesDirectory(),
                     this@PickNoteActivity,
                 )

--- a/app/src/main/java/com/philkes/notallyx/presentation/view/main/BaseNoteAdapter.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/view/main/BaseNoteAdapter.kt
@@ -17,17 +17,13 @@ import com.philkes.notallyx.presentation.view.misc.ItemListener
 import com.philkes.notallyx.presentation.viewmodel.preference.DateFormat
 import com.philkes.notallyx.presentation.viewmodel.preference.NotesSort
 import com.philkes.notallyx.presentation.viewmodel.preference.NotesSortBy
-import com.philkes.notallyx.presentation.viewmodel.preference.TextSize
 import java.io.File
 
 class BaseNoteAdapter(
     private val selectedIds: Set<Long>,
     private val dateFormat: DateFormat,
     private var notesSort: NotesSort,
-    private val textSize: TextSize,
-    private val maxItems: Int,
-    private val maxLines: Int,
-    private val maxTitle: Int,
+    private val preferences: BaseNoteVHPreferences,
     private val imageRoot: File?,
     private val listener: ItemListener,
 ) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
@@ -77,7 +73,7 @@ class BaseNoteAdapter(
             }
             else -> {
                 val binding = RecyclerBaseNoteBinding.inflate(inflater, parent, false)
-                BaseNoteVH(binding, dateFormat, textSize, maxItems, maxLines, maxTitle, listener)
+                BaseNoteVH(binding, dateFormat, preferences, listener)
             }
         }
     }

--- a/app/src/main/java/com/philkes/notallyx/presentation/viewmodel/preference/NotallyXPreferences.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/viewmodel/preference/NotallyXPreferences.kt
@@ -30,7 +30,6 @@ class NotallyXPreferences private constructor(private val app: Application) {
         )
     }
 
-    // Main thread (unfortunately)
     val theme = createEnumPreference(preferences, "theme", Theme.FOLLOW_SYSTEM, R.string.theme)
     val textSize =
         createEnumPreference(preferences, "textSize", TextSize.MEDIUM, R.string.text_size)
@@ -76,6 +75,13 @@ class NotallyXPreferences private constructor(private val app: Application) {
         )
     val labelsHiddenInNavigation =
         StringSetPreference("labelsHiddenInNavigation", preferences, setOf())
+    val labelsHiddenInOverview =
+        BooleanPreference(
+            "labelsHiddenInOverview",
+            preferences,
+            false,
+            R.string.labels_hidden_in_overview_title,
+        )
     val maxLabels =
         IntPreference(
             "maxLabelsInNavigation",

--- a/app/src/main/res/layout/activity_edit.xml
+++ b/app/src/main/res/layout/activity_edit.xml
@@ -9,7 +9,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:orientation="vertical"
-        android:layout_marginBottom="50dp">
+        android:layout_marginBottom="45dp">
 
     <com.google.android.material.appbar.MaterialToolbar
         android:id="@+id/Toolbar"
@@ -213,7 +213,7 @@
     <com.google.android.material.bottomappbar.BottomAppBar
       android:id="@+id/BottomAppBarLayout"
       android:layout_width="match_parent"
-      android:layout_height="50dp"
+      android:layout_height="45dp"
       android:layout_gravity="bottom"
       android:backgroundTint="?attr/colorSurface"
       app:elevation="0dp"
@@ -221,14 +221,14 @@
         <androidx.constraintlayout.widget.ConstraintLayout
           android:id="@+id/BottomAppBar"
           android:layout_width="match_parent"
-          android:layout_height="wrap_content">
+          android:layout_height="match_parent">
             <LinearLayout
               android:id="@+id/BottomAppBarLeft"
               app:layout_constraintStart_toStartOf="parent"
               app:layout_constraintTop_toTopOf="parent"
               app:layout_constraintBottom_toBottomOf="parent"
               android:layout_width="0dp"
-              android:layout_height="wrap_content"
+              android:layout_height="match_parent"
               android:orientation="horizontal"
               >
             </LinearLayout>
@@ -239,7 +239,7 @@
               app:layout_constraintTop_toTopOf="parent"
               app:layout_constraintBottom_toBottomOf="parent"
               android:layout_width="wrap_content"
-              android:layout_height="wrap_content"
+              android:layout_height="match_parent"
               android:orientation="horizontal"
               android:gravity="center_horizontal"
               >
@@ -250,7 +250,7 @@
               app:layout_constraintTop_toTopOf="parent"
               app:layout_constraintBottom_toBottomOf="parent"
               android:layout_width="wrap_content"
-              android:layout_height="wrap_content"
+              android:layout_height="match_parent"
               android:orientation="horizontal"
               >
             </LinearLayout>

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -66,6 +66,10 @@
             android:id="@+id/MaxLines"
             layout="@layout/preference_seekbar" />
 
+        <include
+          android:id="@+id/LabelsHiddenInOverview"
+          layout="@layout/preference" />
+
         <View
             android:layout_width="match_parent"
             android:layout_height="1dp"

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -123,6 +123,7 @@
      <string name="max_lines_to_display_title">Maximal angezeigte Zeilen im Titel</string>
 
     <string name="max_labels_to_display">Max. Anzahl an angezeigten Lables in der Navigation</string>
+    <string name="labels_hidden_in_overview">Ist dies aktiviert, werden die Labels der Notizen in der Übersicht ausgeblendet</string>
     <string name="security">Sicherheit</string>
 
     <string name="biometric_lock">App per Biometrie/PIN sperren</string>
@@ -265,5 +266,6 @@
     <string name="export_settings_success">Einstellungen erfolgreich exportiert</string>
     <string name="export_settings_failure">Import der Einstellungen fehlgeschlagen, wurde die richtige Datei ausgewählt?</string>
     <string name="reset_settings">Einstellungen zurücksetzen</string>
+    <string name="labels_hidden_in_overview_title">Verberge Labels in Übersicht</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -164,6 +164,8 @@
     <string name="max_lines_to_display">Max lines to display in note</string>
     <string name="max_lines_to_display_title">Max lines to display in title</string>
     <string name="max_labels_to_display">Max labels to display in Navigation</string>
+    <string name="labels_hidden_in_overview_title">Hide Labels in Overview</string>
+    <string name="labels_hidden_in_overview">By enabling this, the notes’ labels will be hidden in the overview</string>
 
 
     <string name="security">Security</string>


### PR DESCRIPTION
See #176 

- Added setting to hide labels in notes overview
- Fixes the bottom appbar cutting off the notes content
- Slightly decreased the bottom appbar height + increased size of menu buttons:

  <img src="https://github.com/user-attachments/assets/bce75007-5a2f-47b8-bcb7-fb40191198ec" width=300 />
