### PR TITLE
Fix display of list icon in BaseNoteVH

### DIFF
--- a/app/src/main/java/com/philkes/notallyx/presentation/view/main/BaseNoteVH.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/view/main/BaseNoteVH.kt
@@ -128,9 +128,14 @@ class BaseNoteVH(
                     if (baseNote.hasNoContents() || shouldOnlyDisplayTitle(baseNote)) 0
                     else 8.dp(context)
             )
-            if (baseNote.type == Type.LIST && preferences.maxItems < 1) {
-                setCompoundDrawablesWithIntrinsicBounds(R.drawable.checkbox_small, 0, 0, 0)
-            }
+            setCompoundDrawablesWithIntrinsicBounds(
+                if (baseNote.type == Type.LIST && preferences.maxItems < 1)
+                    R.drawable.checkbox_small
+                else 0,
+                0,
+                0,
+                0,
+            )
         }
 
         if (preferences.hideLabels) {


### PR DESCRIPTION
Fixes #215 

Resets `BaseNoteVH.binding.Title` left drawable if note is not a list