### PR TITLE
Move top more menu actions to bottom in EditActivity

### DIFF
--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/note/EditActivity.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/note/EditActivity.kt
@@ -281,20 +281,20 @@ abstract class EditActivity(private val type: Type) :
                     add(R.string.delete, R.drawable.delete, MenuItem.SHOW_AS_ACTION_ALWAYS) {
                         delete()
                     }
-                    add(R.string.archive, R.drawable.archive) { archive() }
                 }
 
                 Folder.DELETED -> {
-                    add(R.string.restore, R.drawable.restore) { restore() }
-                    add(R.string.delete_forever, R.drawable.delete) { deleteForever() }
+                    add(R.string.restore, R.drawable.restore, MenuItem.SHOW_AS_ACTION_ALWAYS) {
+                        restore()
+                    }
                 }
 
                 Folder.ARCHIVED -> {
-                    add(R.string.delete, R.drawable.delete) { delete() }
-                    add(R.string.unarchive, R.drawable.unarchive) { restore() }
+                    add(R.string.unarchive, R.drawable.unarchive, MenuItem.SHOW_AS_ACTION_ALWAYS) {
+                        restore()
+                    }
                 }
             }
-            add(R.string.share, R.drawable.share) { share() }
         }
 
         searchResultsAmount.mergeSkipFirst(searchResultPos).observe(this) { (amount, pos) ->
@@ -418,32 +418,24 @@ abstract class EditActivity(private val type: Type) :
         binding.BottomAppBarRight.apply {
             removeAllViews()
             addIconButton(R.string.more, R.drawable.more_vert, marginStart = 0) {
-                val additionalActions = listOf(createPinAction()) + createFolderActions()
-                MoreNoteBottomSheet(this@EditActivity, additionalActions)
+                MoreNoteBottomSheet(this@EditActivity, createFolderActions())
                     .show(supportFragmentManager, MoreNoteBottomSheet.TAG)
             }
         }
     }
 
-    protected fun createPinAction() =
-        if (model.pinned) {
-            Action(R.string.unpin, R.drawable.unpin) { pin() }
-        } else {
-            Action(R.string.pin, R.drawable.pin) { pin() }
-        }
-
     protected fun createFolderActions() =
         when (model.folder) {
             Folder.NOTES ->
                 listOf(
-                    Action(R.string.delete, R.drawable.delete, callback = ::delete),
                     Action(R.string.archive, R.drawable.archive, callback = ::archive),
+                    Action(R.string.delete, R.drawable.delete, callback = ::delete),
                 )
 
             Folder.DELETED ->
                 listOf(
-                    Action(R.string.restore, R.drawable.restore, callback = ::restore),
                     Action(R.string.delete_forever, R.drawable.delete, callback = ::deleteForever),
+                    Action(R.string.restore, R.drawable.restore, callback = ::restore),
                 )
 
             Folder.ARCHIVED ->
@@ -564,7 +556,7 @@ abstract class EditActivity(private val type: Type) :
         selectLabelsActivityResultLauncher.launch(intent)
     }
 
-    fun share() {
+    override fun share() {
         val body =
             when (type) {
                 Type.NOTE -> model.body

--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/note/EditListActivity.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/note/EditListActivity.kt
@@ -56,8 +56,7 @@ class EditListActivity : EditActivity(Type.LIST), MoreListActions {
         binding.BottomAppBarRight.apply {
             removeAllViews()
             addIconButton(R.string.more, R.drawable.more_vert, marginStart = 0) {
-                val additionalActions = listOf(createPinAction()) + createFolderActions()
-                MoreListBottomSheet(this@EditListActivity, additionalActions)
+                MoreListBottomSheet(this@EditListActivity, createFolderActions())
                     .show(supportFragmentManager, MoreListBottomSheet.TAG)
             }
         }

--- a/app/src/main/java/com/philkes/notallyx/presentation/view/note/action/MoreNoteBottomSheet.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/view/note/action/MoreNoteBottomSheet.kt
@@ -13,6 +13,7 @@ class MoreNoteBottomSheet(
 
         internal fun createActions(callbacks: MoreActions, additionalActions: Collection<Action>) =
             listOf(
+                Action(R.string.share, R.drawable.share) { callbacks.share() },
                 Action(R.string.change_color, R.drawable.change_color) { callbacks.changeColor() },
                 Action(R.string.labels, R.drawable.label) { callbacks.changeLabels() },
             ) + additionalActions
@@ -20,6 +21,8 @@ class MoreNoteBottomSheet(
 }
 
 interface MoreActions {
+    fun share()
+
     fun changeColor()
 
     fun changeLabels()


### PR DESCRIPTION
Closes #206 

- Moves all actions from the top "..." menu to the bottom "..."
- On the top the remaining actions are: Search, Pin, Delete (or Restore if note is in Deleted, or Unarchive if note is in Archived)

<p> 
  <img src="https://github.com/user-attachments/assets/b51a40ea-1f72-4677-adb7-c2c710dffa0d" width=300 />
  <img src="https://github.com/user-attachments/assets/c3f74aac-8a17-4d29-9c22-1217de1bc5f5" width=300 />
</p>
