### PR TITLE
Add end-ellipsize for Title and Note in BaseNoteVH

### DIFF
--- a/app/src/main/res/layout/recycler_base_note.xml
+++ b/app/src/main/res/layout/recycler_base_note.xml
@@ -77,6 +77,7 @@
             android:fontFamily="sans-serif-medium"
             android:textAppearance="?attr/textAppearanceBodyLarge"
             android:textColor="?attr/colorOnSurface"
+            android:ellipsize="end"
             app:layout_constraintTop_toBottomOf="@id/Space" />
 
         <TextView
@@ -128,6 +129,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:lineSpacingMultiplier="1.1"
+            android:ellipsize="end"
             app:layout_constraintTop_toBottomOf="@id/FileViewLayout" />
 
         <LinearLayout


### PR DESCRIPTION
Closes #220 

Added `ellipsize=end` to Title and Note text in `BaseNoteVH` to show the user if there are more characters in a Note's title and content

With max title lines = 1 and max content lines = 1:
<img src="https://github.com/user-attachments/assets/1ec73fa9-96f7-4b21-90be-249356da27c7" width=300 />
