### PR TITLE
Import either single text file or entire folder + restrict plain text import mimetypes

### DIFF
--- a/app/src/main/java/com/philkes/notallyx/data/imports/NotesImporter.kt
+++ b/app/src/main/java/com/philkes/notallyx/data/imports/NotesImporter.kt
@@ -146,11 +146,11 @@ enum class ImportSource(
     ),
     PLAIN_TEXT(
         R.string.plain_text_files,
-        FOLDER_MIMETYPE,
+        FOLDER_OR_FILE_MIMETYPE,
         R.string.plain_text_files_help,
         null,
         R.drawable.text_file,
     ),
 }
 
-const val FOLDER_MIMETYPE = "FOLDER"
+const val FOLDER_OR_FILE_MIMETYPE = "FOLDER_OR_FILE"

--- a/app/src/main/java/com/philkes/notallyx/data/imports/txt/PlainTextImporter.kt
+++ b/app/src/main/java/com/philkes/notallyx/data/imports/txt/PlainTextImporter.kt
@@ -24,52 +24,53 @@ class PlainTextImporter : ExternalImporter {
         progress: MutableLiveData<ImportProgress>?,
     ): Pair<List<BaseNote>, File?> {
         val notes = mutableListOf<BaseNote>()
-        fun readTxtFiles(folder: DocumentFile) {
-            folder.listFiles().forEach { file ->
-                when {
-                    file.isDirectory -> {
-                        readTxtFiles(file)
-                    }
+        fun readTxtFiles(file: DocumentFile) {
+            when {
+                file.isDirectory -> {
+                    file.listFiles().forEach { readTxtFiles(it) }
+                }
 
-                    file.isFile -> {
-                        val fileNameWithoutExtension = file.name?.substringBeforeLast(".") ?: ""
-                        var content =
-                            app.contentResolver.openInputStream(file.uri)?.use { inputStream ->
-                                BufferedReader(InputStreamReader(inputStream)).use { reader ->
-                                    reader.readText()
-                                }
-                            } ?: ""
-                        val listItems = mutableListOf<ListItem>()
-                        content.findListSyntaxRegex()?.let { listSyntaxRegex ->
-                            listItems.addAll(content.extractListItems(listSyntaxRegex))
-                            content = ""
-                        }
-                        val timestamp = System.currentTimeMillis()
-                        notes.add(
-                            BaseNote(
-                                id = 0L, // Auto-generated
-                                type = if (listItems.isEmpty()) Type.NOTE else Type.LIST,
-                                folder = Folder.NOTES,
-                                color = Color.DEFAULT,
-                                title = fileNameWithoutExtension,
-                                pinned = false,
-                                timestamp = timestamp,
-                                modifiedTimestamp = timestamp,
-                                labels = listOf(),
-                                body = content,
-                                spans = listOf(),
-                                items = listItems,
-                                images = listOf(),
-                                files = listOf(),
-                                audios = listOf(),
-                            )
-                        )
+                file.isFile -> {
+                    val fileNameWithoutExtension = file.name?.substringBeforeLast(".") ?: ""
+                    var content =
+                        app.contentResolver.openInputStream(file.uri)?.use { inputStream ->
+                            BufferedReader(InputStreamReader(inputStream)).use { reader ->
+                                reader.readText()
+                            }
+                        } ?: ""
+                    val listItems = mutableListOf<ListItem>()
+                    content.findListSyntaxRegex()?.let { listSyntaxRegex ->
+                        listItems.addAll(content.extractListItems(listSyntaxRegex))
+                        content = ""
                     }
+                    val timestamp = System.currentTimeMillis()
+                    notes.add(
+                        BaseNote(
+                            id = 0L, // Auto-generated
+                            type = if (listItems.isEmpty()) Type.NOTE else Type.LIST,
+                            folder = Folder.NOTES,
+                            color = Color.DEFAULT,
+                            title = fileNameWithoutExtension,
+                            pinned = false,
+                            timestamp = timestamp,
+                            modifiedTimestamp = timestamp,
+                            labels = listOf(),
+                            body = content,
+                            spans = listOf(),
+                            items = listItems,
+                            images = listOf(),
+                            files = listOf(),
+                            audios = listOf(),
+                        )
+                    )
                 }
             }
         }
-        DocumentFile.fromTreeUri(app, source)?.let { readTxtFiles(it) }
-
+        val file =
+            if (source.pathSegments.firstOrNull() == "tree") {
+                DocumentFile.fromTreeUri(app, source)
+            } else DocumentFile.fromSingleUri(app, source)
+        file?.let { readTxtFiles(it) }
         return Pair(notes, null)
     }
 }

--- a/app/src/main/java/com/philkes/notallyx/data/imports/txt/PlainTextImporter.kt
+++ b/app/src/main/java/com/philkes/notallyx/data/imports/txt/PlainTextImporter.kt
@@ -31,6 +31,9 @@ class PlainTextImporter : ExternalImporter {
                 }
 
                 file.isFile -> {
+                    if (file.type?.isTextMimeType() == false) {
+                        return
+                    }
                     val fileNameWithoutExtension = file.name?.substringBeforeLast(".") ?: ""
                     var content =
                         app.contentResolver.openInputStream(file.uri)?.use { inputStream ->
@@ -73,4 +76,17 @@ class PlainTextImporter : ExternalImporter {
         file?.let { readTxtFiles(it) }
         return Pair(notes, null)
     }
+
+    private fun String.isTextMimeType(): Boolean {
+        return startsWith("text/") || this in APPLICATION_TEXT_MIME_TYPES
+    }
 }
+
+val APPLICATION_TEXT_MIME_TYPES =
+    arrayOf(
+        "application/json",
+        "application/xml",
+        "application/javascript",
+        "application/xhtml+xml",
+        "application/yaml",
+    )

--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/main/fragment/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/main/fragment/settings/SettingsFragment.kt
@@ -23,6 +23,7 @@ import com.philkes.notallyx.NotallyXApplication
 import com.philkes.notallyx.R
 import com.philkes.notallyx.data.imports.FOLDER_OR_FILE_MIMETYPE
 import com.philkes.notallyx.data.imports.ImportSource
+import com.philkes.notallyx.data.imports.txt.APPLICATION_TEXT_MIME_TYPES
 import com.philkes.notallyx.databinding.FragmentSettingsBinding
 import com.philkes.notallyx.databinding.TextInputDialogBinding
 import com.philkes.notallyx.presentation.addCancelButton
@@ -332,8 +333,13 @@ class SettingsFragment : Fragment() {
                                             1 ->
                                                 importOtherActivityResultLauncher.launch(
                                                     Intent(Intent.ACTION_OPEN_DOCUMENT).apply {
-                                                        type = "*/*"
+                                                        type = "text/*"
                                                         addCategory(Intent.CATEGORY_OPENABLE)
+                                                        putExtra(
+                                                            Intent.EXTRA_MIME_TYPES,
+                                                            arrayOf("text/*") +
+                                                                APPLICATION_TEXT_MIME_TYPES,
+                                                        )
                                                     }
                                                 )
                                         }

--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/main/fragment/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/main/fragment/settings/SettingsFragment.kt
@@ -21,7 +21,7 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.textfield.TextInputLayout.END_ICON_PASSWORD_TOGGLE
 import com.philkes.notallyx.NotallyXApplication
 import com.philkes.notallyx.R
-import com.philkes.notallyx.data.imports.FOLDER_MIMETYPE
+import com.philkes.notallyx.data.imports.FOLDER_OR_FILE_MIMETYPE
 import com.philkes.notallyx.data.imports.ImportSource
 import com.philkes.notallyx.databinding.FragmentSettingsBinding
 import com.philkes.notallyx.databinding.TextInputDialogBinding
@@ -312,14 +312,36 @@ class SettingsFragment : Fragment() {
                     .setMessage(selectedImportSource.helpTextResId)
                     .setPositiveButton(R.string.import_action) { dialog, _ ->
                         dialog.cancel()
-                        val intent =
-                            when (selectedImportSource.mimeType) {
-                                FOLDER_MIMETYPE ->
-                                    Intent(Intent.ACTION_OPEN_DOCUMENT_TREE).apply {
-                                        addCategory(Intent.CATEGORY_DEFAULT)
+                        when (selectedImportSource.mimeType) {
+                            FOLDER_OR_FILE_MIMETYPE ->
+                                MaterialAlertDialogBuilder(requireContext())
+                                    .setTitle(R.string.plain_text_files)
+                                    .setItems(
+                                        arrayOf(
+                                            getString(R.string.folder),
+                                            getString(R.string.single_file),
+                                        )
+                                    ) { _, which ->
+                                        when (which) {
+                                            0 ->
+                                                importOtherActivityResultLauncher.launch(
+                                                    Intent(Intent.ACTION_OPEN_DOCUMENT_TREE).apply {
+                                                        addCategory(Intent.CATEGORY_DEFAULT)
+                                                    }
+                                                )
+                                            1 ->
+                                                importOtherActivityResultLauncher.launch(
+                                                    Intent(Intent.ACTION_OPEN_DOCUMENT).apply {
+                                                        type = "*/*"
+                                                        addCategory(Intent.CATEGORY_OPENABLE)
+                                                    }
+                                                )
+                                        }
                                     }
-
-                                else ->
+                                    .addCancelButton()
+                                    .show()
+                            else ->
+                                importOtherActivityResultLauncher.launch(
                                     Intent(Intent.ACTION_OPEN_DOCUMENT).apply {
                                         type = "application/*"
                                         putExtra(
@@ -328,8 +350,8 @@ class SettingsFragment : Fragment() {
                                         )
                                         addCategory(Intent.CATEGORY_OPENABLE)
                                     }
-                            }
-                        importOtherActivityResultLauncher.launch(intent)
+                                )
+                        }
                     }
                     .also {
                         selectedImportSource.documentationUrl?.let<String, Unit> { docUrl ->

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -148,7 +148,7 @@
     <string name="google_keep_help">Um deine Notizen aus Google Notizen zu importieren musst du deine Google Takeout ZIP Datei herunterladen\n\nFalls du das Takeout ZIP schon hast, klicke auf Import und wähle es aus.</string>
     <string name="exporting_backup">Backup Exportieren</string>
     <string name="importing_backup">Backup Importieren</string>
-    <string name="plain_text_files_help">Um deine Text-Notizen zu importieren, klicke Import und wähle den Ordner mit den Textdateien aus.\n\nJede Datei wird als einzelne Notiz importiert, der Dateiname wird zum Notiz-Titel. Sollte der Textinhalt mit einer List-Syntax beginnen (z.B. Markdown ’- [x]’, NotallyX syntax ’[✓]’, or ’*’, ’-’), wird die Datei als List-Notiz importiert.</string>
+    <string name="plain_text_files_help">Um deine Text-Notizen (einzele Datei oder Ordner) zu importieren, klicke Import.\n\nJede Datei wird als einzelne Notiz importiert, der Dateiname wird zum Notiz-Titel. Sollte der Textinhalt mit einer List-Syntax beginnen (z.B. Markdown ’- [x]’, NotallyX syntax ’[✓]’, or ’*’, ’-’), wird die Datei als List-Notiz importiert.</string>
     <string name="imported_notes">Notizen importiert</string>
     <string name="calculating">Berechne…</string>
     <string name="clear_data_message">Alle Notizen, Bilder, Dateien und Sprachnotizen werden permanent gelöscht</string>
@@ -157,6 +157,8 @@
     <string name="google_keep">Google Notizen</string>
 
     <string name="plain_text_files">Text Dateien</string>
+    <string name="single_file">Einzelne Datei</string>
+    <string name="folder">Ordner</string>
     <string name="export_backup">Backup erstellen</string>
     <string name="import_backup">Backup importieren</string>
     <string name="clear_data">Alle Daten löschen</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -189,7 +189,7 @@
     <string name="google_keep_help">Pour importer vos notes depuis Google Keep, vous devez télécharger votre fichier ZIP Google Takeout. Cliquez sur "Aide" pour plus d
 	information.\n\nSi vous possédez déjà un fichier ZIP Google Takeout, cliquez sur "Importer" et choisissez le fichier ZIP.</string>
     <string name="evernote_help">Pour importer vos notes depuis Evernote, vous devez exporter votre carnet de notes Evernote au format ENEX. Cliquez sur "Aide" pour plus d\'information.\n\nSi vous possédez déjà un fichier ENEX, cliquez sur "Importer" et sélectionnez-le.</string>
-    <string name="plain_text_files_help">Pour importer vos notes à partir de fichiers texte bruts, cliquez sur "Importer" et choisissez le dossier contenant les fichiers texte. Chaque fichier est importé comme une note séparée, le nom du fichier devient le titre de la note. Si le contenu du texte commence par une syntaxe de liste (par exemple, Markdown ‘- [x]’, syntaxe NotallyX ‘[✓]’, ou ‘*’, ‘-’), il sera converti en une note sous forme de liste.</string>
+    <string name="plain_text_files_help">Pour importer vos notes à partir de fichiers (un seul fichier ou dossier) texte bruts, cliquez sur "Importer". Chaque fichier est importé comme une note séparée, le nom du fichier devient le titre de la note. Si le contenu du texte commence par une syntaxe de liste (par exemple, Markdown ‘- [x]’, syntaxe NotallyX ‘[✓]’, ou ‘*’, ‘-’), il sera converti en une note sous forme de liste.</string>
     <plurals name="imported_notes">
         <item quantity="one">%s note importée</item>
         <item quantity="other">%s notes importées</item>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -191,7 +191,7 @@
     <string name="help">Aiuto</string>
     <string name="google_keep_help">Per importare le note da Google Keep devi scaricare il tuo file ZIP di Google Takeout. Clicca su Aiuto per ulteriori informazioni.\n\nSe hai già un file ZIP di Takeout, clicca Importa e selezionalo.</string>
     <string name="evernote_help">Per importare le note da Evernote devi esportare il tuo Notebook Evernote come ENEX. Clicca su Aiuto per ulteriori informazioni.\n\nSe hai già un file ENEX, clicca Importa e selezionalo.</string>
-    <string name="plain_text_files_help">Per importare le note da file di testo semplice, clicca Importa e seleziona la cartella che contiene i file di testo. Ogni file verrà importato in una nota separata, il nome del file diventerà il titolo della nota. Se il contenuto inizia con la sintassi di lista (per esempio ’- [x]’ in Markdown, ’[✓]’ nella sintassi di Notallyx, oppure ’*’, ’-’) verrà importato come Lista.</string>
+    <string name="plain_text_files_help">Per importare le note da file (singolo file o cartella) di testo semplice, clicca Importa. Ogni file verrà importato in una nota separata, il nome del file diventerà il titolo della nota. Se il contenuto inizia con la sintassi di lista (per esempio ’- [x]’ in Markdown, ’[✓]’ nella sintassi di Notallyx, oppure ’*’, ’-’) verrà importato come Lista.</string>
     <plurals name="imported_notes">
         <item quantity="one">Importata %s nota</item>
         <item quantity="other">Importate %s note</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -195,7 +195,7 @@
     <string name="help">Help</string>
     <string name="google_keep_help">In order to import your Notes from Google Keep you must download your Google Takeout ZIP file. Click Help to get more information.\n\nIf you already have a Takeout ZIP file, click Import and choose the ZIP file.</string>
     <string name="evernote_help">In order to import your Notes from Evernote you must export your Evernote Notebook as ENEX. Click Help to get more information.\n\nIf you already have a ENEX file, click Import and choose it.</string>
-    <string name="plain_text_files_help">In order to import your Notes from plain text files, click Import and choose the folder containing the text files.  Every file is imported as a separate note, the file’s name becomes the note’s title. If the text contents start with list syntax (e.g. Markdown ’- [x]’, NotallyX syntax ’[✓]’, or ’*’, ’-’) it will be converted to a List note.</string>
+    <string name="plain_text_files_help">In order to import your Notes from plain text files (single file or folder), click Import. Every file is imported as a separate note, the file’s name becomes the note’s title. If the text contents start with list syntax (e.g. Markdown ’- [x]’, NotallyX syntax ’[✓]’, or ’*’, ’-’) it will be converted to a List note.</string>
     <plurals name="imported_notes">
         <item quantity="one">Imported %s Note</item>
         <item quantity="other">Imported %s Notes</item>
@@ -214,6 +214,8 @@
     <string name="google_keep">Google Keep</string>
     <string name="evernote">Evernote</string>
     <string name="plain_text_files">Plain Text Files</string>
+    <string name="single_file">Single File</string>
+    <string name="folder">Folder</string>
 
     <string name="export_backup">Export backup</string>
     <string name="import_backup">Import backup</string>


### PR DESCRIPTION
Fixes #209 

- Allows to either pick a single text file or an entire folder
- Restricts text files import to the following file mimetypes (other file types are ignored):
  - `text/*`
  - `application/json`
  - `application/xml`
  - `application/javascript`
  - `application/xhtml+xml`
  - `application/yaml`

[notallyx_issues_209.webm](https://github.com/user-attachments/assets/c282a7f3-335c-4e72-931d-9b17b6cca14c)
