### PR TITLE
Add IntentChooser to all external app Intents

### DIFF
--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/main/MainActivity.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/main/MainActivity.kt
@@ -66,6 +66,7 @@ import com.philkes.notallyx.utils.IO.getExportedPath
 import com.philkes.notallyx.utils.Operations
 import com.philkes.notallyx.utils.backup.Export.exportPdfFile
 import com.philkes.notallyx.utils.backup.Export.exportPlainTextFile
+import com.philkes.notallyx.utils.wrapWithChooser
 import java.io.File
 import kotlinx.coroutines.launch
 
@@ -388,9 +389,9 @@ class MainActivity : LockedActivity<ActivityMainBinding>() {
         } else {
             lifecycleScope.launch {
                 val intent =
-                    Intent(Intent.ACTION_OPEN_DOCUMENT_TREE).apply {
-                        addCategory(Intent.CATEGORY_DEFAULT)
-                    }
+                    Intent(Intent.ACTION_OPEN_DOCUMENT_TREE)
+                        .apply { addCategory(Intent.CATEGORY_DEFAULT) }
+                        .wrapWithChooser(this@MainActivity)
                 model.selectedExportMimeType = mimeType
                 exportNotesActivityResultLauncher.launch(intent)
             }
@@ -406,22 +407,24 @@ class MainActivity : LockedActivity<ActivityMainBinding>() {
 
     private fun viewFile(uri: Uri, mimeType: String) {
         val intent =
-            Intent(Intent.ACTION_VIEW).apply {
-                setDataAndType(uri, mimeType)
-                flags = Intent.FLAG_GRANT_READ_URI_PERMISSION
-            }
-
-        val chooser = Intent.createChooser(intent, getString(R.string.view_note))
-        startActivity(chooser)
+            Intent(Intent.ACTION_VIEW)
+                .apply {
+                    setDataAndType(uri, mimeType)
+                    flags = Intent.FLAG_GRANT_READ_URI_PERMISSION
+                }
+                .wrapWithChooser(this@MainActivity)
+        startActivity(intent)
     }
 
     private fun saveFileToDevice(file: DocumentFile, mimeType: String) {
         val intent =
-            Intent(Intent.ACTION_CREATE_DOCUMENT).apply {
-                type = mimeType
-                addCategory(Intent.CATEGORY_OPENABLE)
-                putExtra(Intent.EXTRA_TITLE, file.nameWithoutExtension!!)
-            }
+            Intent(Intent.ACTION_CREATE_DOCUMENT)
+                .apply {
+                    type = mimeType
+                    addCategory(Intent.CATEGORY_OPENABLE)
+                    putExtra(Intent.EXTRA_TITLE, file.nameWithoutExtension!!)
+                }
+                .wrapWithChooser(this@MainActivity)
         model.selectedExportFile = file
         exportFileActivityResultLauncher.launch(intent)
     }

--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/main/fragment/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/main/fragment/settings/SettingsFragment.kt
@@ -45,6 +45,7 @@ import com.philkes.notallyx.utils.Operations.reportBug
 import com.philkes.notallyx.utils.security.decryptDatabase
 import com.philkes.notallyx.utils.security.encryptDatabase
 import com.philkes.notallyx.utils.security.showBiometricOrPinPrompt
+import com.philkes.notallyx.utils.wrapWithChooser
 
 class SettingsFragment : Fragment() {
 
@@ -256,21 +257,28 @@ class SettingsFragment : Fragment() {
         binding.apply {
             ImportBackup.setOnClickListener {
                 val intent =
-                    Intent(Intent.ACTION_OPEN_DOCUMENT).apply {
-                        type = "*/*"
-                        putExtra(Intent.EXTRA_MIME_TYPES, arrayOf("application/zip", "text/xml"))
-                        addCategory(Intent.CATEGORY_OPENABLE)
-                    }
+                    Intent(Intent.ACTION_OPEN_DOCUMENT)
+                        .apply {
+                            type = "*/*"
+                            putExtra(
+                                Intent.EXTRA_MIME_TYPES,
+                                arrayOf("application/zip", "text/xml"),
+                            )
+                            addCategory(Intent.CATEGORY_OPENABLE)
+                        }
+                        .wrapWithChooser(requireContext())
                 importBackupActivityResultLauncher.launch(intent)
             }
             ImportOther.setOnClickListener { importFromOtherApp() }
             ExportBackup.setOnClickListener {
                 val intent =
-                    Intent(Intent.ACTION_CREATE_DOCUMENT).apply {
-                        type = "application/zip"
-                        addCategory(Intent.CATEGORY_OPENABLE)
-                        putExtra(Intent.EXTRA_TITLE, "NotallyX Backup")
-                    }
+                    Intent(Intent.ACTION_CREATE_DOCUMENT)
+                        .apply {
+                            type = "application/zip"
+                            addCategory(Intent.CATEGORY_OPENABLE)
+                            putExtra(Intent.EXTRA_TITLE, "NotallyX Backup")
+                        }
+                        .wrapWithChooser(requireContext())
                 exportBackupActivityResultLauncher.launch(intent)
             }
         }
@@ -326,21 +334,25 @@ class SettingsFragment : Fragment() {
                                         when (which) {
                                             0 ->
                                                 importOtherActivityResultLauncher.launch(
-                                                    Intent(Intent.ACTION_OPEN_DOCUMENT_TREE).apply {
-                                                        addCategory(Intent.CATEGORY_DEFAULT)
-                                                    }
+                                                    Intent(Intent.ACTION_OPEN_DOCUMENT_TREE)
+                                                        .apply {
+                                                            addCategory(Intent.CATEGORY_DEFAULT)
+                                                        }
+                                                        .wrapWithChooser(requireContext())
                                                 )
                                             1 ->
                                                 importOtherActivityResultLauncher.launch(
-                                                    Intent(Intent.ACTION_OPEN_DOCUMENT).apply {
-                                                        type = "text/*"
-                                                        addCategory(Intent.CATEGORY_OPENABLE)
-                                                        putExtra(
-                                                            Intent.EXTRA_MIME_TYPES,
-                                                            arrayOf("text/*") +
-                                                                APPLICATION_TEXT_MIME_TYPES,
-                                                        )
-                                                    }
+                                                    Intent(Intent.ACTION_OPEN_DOCUMENT)
+                                                        .apply {
+                                                            type = "text/*"
+                                                            addCategory(Intent.CATEGORY_OPENABLE)
+                                                            putExtra(
+                                                                Intent.EXTRA_MIME_TYPES,
+                                                                arrayOf("text/*") +
+                                                                    APPLICATION_TEXT_MIME_TYPES,
+                                                            )
+                                                        }
+                                                        .wrapWithChooser(requireContext())
                                                 )
                                         }
                                     }
@@ -348,14 +360,16 @@ class SettingsFragment : Fragment() {
                                     .show()
                             else ->
                                 importOtherActivityResultLauncher.launch(
-                                    Intent(Intent.ACTION_OPEN_DOCUMENT).apply {
-                                        type = "application/*"
-                                        putExtra(
-                                            Intent.EXTRA_MIME_TYPES,
-                                            arrayOf(selectedImportSource.mimeType),
-                                        )
-                                        addCategory(Intent.CATEGORY_OPENABLE)
-                                    }
+                                    Intent(Intent.ACTION_OPEN_DOCUMENT)
+                                        .apply {
+                                            type = "application/*"
+                                            putExtra(
+                                                Intent.EXTRA_MIME_TYPES,
+                                                arrayOf(selectedImportSource.mimeType),
+                                            )
+                                            addCategory(Intent.CATEGORY_OPENABLE)
+                                        }
+                                        .wrapWithChooser(requireContext())
                                 )
                         }
                     }
@@ -363,7 +377,9 @@ class SettingsFragment : Fragment() {
                         selectedImportSource.documentationUrl?.let<String, Unit> { docUrl ->
                             it.setNegativeButton(R.string.help) { _, _ ->
                                 val intent =
-                                    Intent(Intent.ACTION_VIEW).apply { data = Uri.parse(docUrl) }
+                                    Intent(Intent.ACTION_VIEW)
+                                        .apply { data = Uri.parse(docUrl) }
+                                        .wrapWithChooser(requireContext())
                                 startActivity(intent)
                             }
                         }
@@ -405,22 +421,26 @@ class SettingsFragment : Fragment() {
             ImportSettings.setOnClickListener {
                 showDialog(R.string.import_settings_message, R.string.import_action) { _, _ ->
                     val intent =
-                        Intent(Intent.ACTION_OPEN_DOCUMENT).apply {
-                            type = "application/json"
-                            addCategory(Intent.CATEGORY_OPENABLE)
-                            putExtra(Intent.EXTRA_TITLE, "NotallyX_Settings.json")
-                        }
+                        Intent(Intent.ACTION_OPEN_DOCUMENT)
+                            .apply {
+                                type = "application/json"
+                                addCategory(Intent.CATEGORY_OPENABLE)
+                                putExtra(Intent.EXTRA_TITLE, "NotallyX_Settings.json")
+                            }
+                            .wrapWithChooser(requireContext())
                     importSettingsActivityResultLauncher.launch(intent)
                 }
             }
             ExportSettings.setOnClickListener {
                 showDialog(R.string.export_settings_message, R.string.export) { _, _ ->
                     val intent =
-                        Intent(Intent.ACTION_CREATE_DOCUMENT).apply {
-                            type = "application/json"
-                            addCategory(Intent.CATEGORY_OPENABLE)
-                            putExtra(Intent.EXTRA_TITLE, "NotallyX_Settings.json")
-                        }
+                        Intent(Intent.ACTION_CREATE_DOCUMENT)
+                            .apply {
+                                type = "application/json"
+                                addCategory(Intent.CATEGORY_OPENABLE)
+                                putExtra(Intent.EXTRA_TITLE, "NotallyX_Settings.json")
+                            }
+                            .wrapWithChooser(requireContext())
                     exportSettingsActivityResultLauncher.launch(intent)
                 }
             }
@@ -445,17 +465,19 @@ class SettingsFragment : Fragment() {
         binding.apply {
             SendFeedback.setOnClickListener {
                 val intent =
-                    Intent(Intent.ACTION_SEND).apply {
-                        selector = Intent(Intent.ACTION_SENDTO, Uri.parse("mailto:"))
-                        putExtra(Intent.EXTRA_EMAIL, arrayOf("notallyx@yahoo.com"))
-                        putExtra(Intent.EXTRA_SUBJECT, "NotallyX [Feedback]")
-                        val app = requireContext().applicationContext as Application
-                        val log = Operations.getLog(app)
-                        if (log.exists()) {
-                            val uri = app.getUriForFile(log)
-                            putExtra(Intent.EXTRA_STREAM, uri)
+                    Intent(Intent.ACTION_SEND)
+                        .apply {
+                            selector = Intent(Intent.ACTION_SENDTO, Uri.parse("mailto:"))
+                            putExtra(Intent.EXTRA_EMAIL, arrayOf("notallyx@yahoo.com"))
+                            putExtra(Intent.EXTRA_SUBJECT, "NotallyX [Feedback]")
+                            val app = requireContext().applicationContext as Application
+                            val log = Operations.getLog(app)
+                            if (log.exists()) {
+                                val uri = app.getUriForFile(log)
+                                putExtra(Intent.EXTRA_STREAM, uri)
+                            }
                         }
-                    }
+                        .wrapWithChooser(requireContext())
                 try {
                     startActivity(intent)
                 } catch (exception: ActivityNotFoundException) {
@@ -482,11 +504,12 @@ class SettingsFragment : Fragment() {
                                 requireContext().catchNoBrowserInstalled {
                                     startActivity(
                                         Intent(
-                                            Intent.ACTION_VIEW,
-                                            Uri.parse(
-                                                "https://github.com/PhilKes/NotallyX/issues/new?labels=enhancement&template=feature_request.md"
-                                            ),
-                                        )
+                                                Intent.ACTION_VIEW,
+                                                Uri.parse(
+                                                    "https://github.com/PhilKes/NotallyX/issues/new?labels=enhancement&template=feature_request.md"
+                                                ),
+                                            )
+                                            .wrapWithChooser(requireContext())
                                     )
                                 }
                         }
@@ -579,7 +602,7 @@ class SettingsFragment : Fragment() {
 
     private fun displayChooseBackupFolderDialog() {
         showDialog(R.string.notes_will_be, R.string.choose_folder) { _, _ ->
-            val intent = Intent(Intent.ACTION_OPEN_DOCUMENT_TREE)
+            val intent = Intent(Intent.ACTION_OPEN_DOCUMENT_TREE).wrapWithChooser(requireContext())
             chooseBackupFolderActivityResultLauncher.launch(intent)
         }
     }
@@ -642,11 +665,7 @@ class SettingsFragment : Fragment() {
 
     private fun openLink(link: String) {
         val uri = Uri.parse(link)
-        val intent = Intent(Intent.ACTION_VIEW, uri)
-        try {
-            startActivity(intent)
-        } catch (exception: ActivityNotFoundException) {
-            showToast(R.string.install_a_browser)
-        }
+        val intent = Intent(Intent.ACTION_VIEW, uri).wrapWithChooser(requireContext())
+        startActivity(intent)
     }
 }

--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/note/EditNoteActivity.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/note/EditNoteActivity.kt
@@ -49,6 +49,7 @@ import com.philkes.notallyx.presentation.view.note.action.AddNoteBottomSheet
 import com.philkes.notallyx.utils.LinkMovementMethod
 import com.philkes.notallyx.utils.copyToClipBoard
 import com.philkes.notallyx.utils.findAllOccurrences
+import com.philkes.notallyx.utils.wrapWithChooser
 
 class EditNoteActivity : EditActivity(Type.NOTE), AddNoteActions {
 
@@ -401,7 +402,7 @@ class EditNoteActivity : EditActivity(Type.NOTE), AddNoteActions {
 
     private fun openLink(url: String) {
         val uri = Uri.parse(url)
-        val intent = Intent(Intent.ACTION_VIEW, uri)
+        val intent = Intent(Intent.ACTION_VIEW, uri).wrapWithChooser(this)
         try {
             startActivity(intent)
         } catch (exception: Exception) {

--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/note/PlayAudioActivity.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/note/PlayAudioActivity.kt
@@ -21,6 +21,7 @@ import com.philkes.notallyx.presentation.getUriForFile
 import com.philkes.notallyx.utils.IO.getExternalAudioDirectory
 import com.philkes.notallyx.utils.audio.AudioPlayService
 import com.philkes.notallyx.utils.audio.LocalBinder
+import com.philkes.notallyx.utils.wrapWithChooser
 import java.io.File
 import java.io.FileInputStream
 import java.io.FileOutputStream
@@ -113,15 +114,14 @@ class PlayAudioActivity : LockedActivity<ActivityPlayAudioBinding>() {
         val file = if (audioRoot != null) File(audioRoot, audio.name) else null
         if (file != null && file.exists()) {
             val uri = getUriForFile(file)
-
             val intent =
-                Intent(Intent.ACTION_SEND).apply {
-                    type = "audio/mp4"
-                    putExtra(Intent.EXTRA_STREAM, uri)
-                }
-
-            val chooser = Intent.createChooser(intent, null)
-            startActivity(chooser)
+                Intent(Intent.ACTION_SEND)
+                    .apply {
+                        type = "audio/mp4"
+                        putExtra(Intent.EXTRA_STREAM, uri)
+                    }
+                    .wrapWithChooser(this@PlayAudioActivity)
+            startActivity(intent)
         }
     }
 
@@ -143,10 +143,12 @@ class PlayAudioActivity : LockedActivity<ActivityPlayAudioBinding>() {
         val file = if (audioRoot != null) File(audioRoot, audio.name) else null
         if (file != null && file.exists()) {
             val intent =
-                Intent(Intent.ACTION_CREATE_DOCUMENT).apply {
-                    type = "audio/mp4"
-                    addCategory(Intent.CATEGORY_OPENABLE)
-                }
+                Intent(Intent.ACTION_CREATE_DOCUMENT)
+                    .apply {
+                        type = "audio/mp4"
+                        addCategory(Intent.CATEGORY_OPENABLE)
+                    }
+                    .wrapWithChooser(this)
 
             val formatter = DateFormat.getDateTimeInstance(DateFormat.FULL, DateFormat.SHORT)
             val title = formatter.format(audio.timestamp)

--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/note/ViewImageActivity.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/note/ViewImageActivity.kt
@@ -24,6 +24,7 @@ import com.philkes.notallyx.presentation.getUriForFile
 import com.philkes.notallyx.presentation.view.Constants
 import com.philkes.notallyx.presentation.view.note.image.ImageAdapter
 import com.philkes.notallyx.utils.IO.getExternalImagesDirectory
+import com.philkes.notallyx.utils.wrapWithChooser
 import java.io.File
 import java.io.FileInputStream
 import java.io.FileOutputStream
@@ -157,18 +158,19 @@ class ViewImageActivity : LockedActivity<ActivityViewImageBinding>() {
             val uri = getUriForFile(file)
 
             val intent =
-                Intent(Intent.ACTION_SEND).apply {
-                    type = image.mimeType
-                    putExtra(Intent.EXTRA_STREAM, uri)
+                Intent(Intent.ACTION_SEND)
+                    .apply {
+                        type = image.mimeType
+                        putExtra(Intent.EXTRA_STREAM, uri)
 
-                    // Necessary for sharesheet to show a preview of the image
-                    // Check ->
-                    // https://commonsware.com/blog/2021/01/07/action_send-share-sheet-clipdata.html
-                    clipData = ClipData.newRawUri(null, uri)
-                    addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
-                }
-            val chooser = Intent.createChooser(intent, null)
-            startActivity(chooser)
+                        // Necessary for sharesheet to show a preview of the image
+                        // Check ->
+                        // https://commonsware.com/blog/2021/01/07/action_send-share-sheet-clipdata.html
+                        clipData = ClipData.newRawUri(null, uri)
+                        addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                    }
+                    .wrapWithChooser(this@ViewImageActivity)
+            startActivity(intent)
         }
     }
 
@@ -177,11 +179,13 @@ class ViewImageActivity : LockedActivity<ActivityViewImageBinding>() {
         val file = if (mediaRoot != null) File(mediaRoot, image.localName) else null
         if (file != null && file.exists()) {
             val intent =
-                Intent(Intent.ACTION_CREATE_DOCUMENT).apply {
-                    type = image.mimeType
-                    addCategory(Intent.CATEGORY_OPENABLE)
-                    putExtra(Intent.EXTRA_TITLE, "NotallyX Image")
-                }
+                Intent(Intent.ACTION_CREATE_DOCUMENT)
+                    .apply {
+                        type = image.mimeType
+                        addCategory(Intent.CATEGORY_OPENABLE)
+                        putExtra(Intent.EXTRA_TITLE, "NotallyX Image")
+                    }
+                    .wrapWithChooser(this)
             currentImage = image
             exportFileActivityResultLauncher.launch(intent)
         }

--- a/app/src/main/java/com/philkes/notallyx/utils/Extensions.kt
+++ b/app/src/main/java/com/philkes/notallyx/utils/Extensions.kt
@@ -6,6 +6,7 @@ import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.ContentResolver
 import android.content.Context
+import android.content.Intent
 import android.content.pm.PackageManager
 import android.hardware.biometrics.BiometricManager
 import android.net.Uri
@@ -139,3 +140,6 @@ fun String.findAllOccurrences(
         .map { match -> match.range.first to match.range.last + 1 }
         .toList()
 }
+
+fun Intent.wrapWithChooser(context: Context, titleResId: Int? = null): Intent =
+    Intent.createChooser(this, titleResId?.let { context.getText(it) })

--- a/app/src/main/java/com/philkes/notallyx/utils/Operations.kt
+++ b/app/src/main/java/com/philkes/notallyx/utils/Operations.kt
@@ -100,15 +100,16 @@ object Operations {
     fun shareNote(context: Context, title: String, body: CharSequence) {
         val text = body.toString()
         val intent =
-            Intent(Intent.ACTION_SEND).apply {
-                type = "text/plain"
-                putExtra(extraCharSequence, body)
-                putExtra(Intent.EXTRA_TEXT, text)
-                putExtra(Intent.EXTRA_TITLE, title)
-                putExtra(Intent.EXTRA_SUBJECT, title)
-            }
-        val chooser = Intent.createChooser(intent, null)
-        context.startActivity(chooser)
+            Intent(Intent.ACTION_SEND)
+                .apply {
+                    type = "text/plain"
+                    putExtra(extraCharSequence, body)
+                    putExtra(Intent.EXTRA_TEXT, text)
+                    putExtra(Intent.EXTRA_TITLE, title)
+                    putExtra(Intent.EXTRA_SUBJECT, title)
+                }
+                .wrapWithChooser(context)
+        context.startActivity(intent)
     }
 
     fun getBody(list: List<ListItem>) = buildString {
@@ -153,7 +154,7 @@ object Operations {
 
     fun Fragment.reportBug(stackTrace: String?) {
         requireContext().catchNoBrowserInstalled {
-            startActivity(createReportBugIntent(stackTrace))
+            startActivity(requireContext().createReportBugIntent(stackTrace))
         }
     }
 
@@ -169,14 +170,15 @@ object Operations {
         }
     }
 
-    private fun createReportBugIntent(stackTrace: String?): Intent {
+    private fun Context.createReportBugIntent(stackTrace: String?): Intent {
         return Intent(
-            Intent.ACTION_VIEW,
-            Uri.parse(
-                "https://github.com/PhilKes/NotallyX/issues/new?labels=bug&projects=&template=bug_report.yml&version=${BuildConfig.VERSION_NAME}&android-version=${Build.VERSION.SDK_INT}${stackTrace?.let {  "&logs=$stackTrace"} ?: ""}"
-                    .take(2000)
-            ),
-        )
+                Intent.ACTION_VIEW,
+                Uri.parse(
+                    "https://github.com/PhilKes/NotallyX/issues/new?labels=bug&projects=&template=bug_report.yml&version=${BuildConfig.VERSION_NAME}&android-version=${Build.VERSION.SDK_INT}${stackTrace?.let {  "&logs=$stackTrace"} ?: ""}"
+                        .take(2000)
+                ),
+            )
+            .wrapWithChooser(this)
     }
 
     private fun getOutlinedDrawable(context: Context): MaterialShapeDrawable {


### PR DESCRIPTION
Fixes #227

Wraps all `Intent`s that use an external app (like picking a file/folder, opening link/file,...) in a `IntentChooser`. If the user has multiple possible receiver apps for the given Intent it will let the user select one, e.g. when trying to open a PDF file:

[notallyx_issues_227.webm](https://github.com/user-attachments/assets/a6905b5c-2189-4e87-a083-9a2ea80e422b)

If the user has no compatible app installed he will see:

<img src="https://github.com/user-attachments/assets/78811a5c-1936-481e-b7ce-59ce8f52a193" width=300 />
