### PR TITLE
Limit sharing to 150000 characters due not exceed builtin limit

### DIFF
--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/note/EditActivity.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/note/EditActivity.kt
@@ -488,11 +488,9 @@ abstract class EditActivity(private val type: Type) :
         val title = intent.getStringExtra(Intent.EXTRA_SUBJECT)
 
         val string = intent.getStringExtra(Intent.EXTRA_TEXT)
-        val charSequence = intent.getCharSequenceExtra(Operations.extraCharSequence)
-        val body = charSequence ?: string
 
-        if (body != null) {
-            notallyModel.body = Editable.Factory.getInstance().newEditable(body)
+        if (string != null) {
+            notallyModel.body = Editable.Factory.getInstance().newEditable(string)
         }
         if (title != null) {
             notallyModel.title = title

--- a/app/src/main/java/com/philkes/notallyx/utils/Extensions.kt
+++ b/app/src/main/java/com/philkes/notallyx/utils/Extensions.kt
@@ -119,7 +119,7 @@ fun Context.canAuthenticateWithBiometrics(): Int {
     return BiometricManager.BIOMETRIC_ERROR_NO_HARDWARE
 }
 
-fun String.truncate(limit: Int): String {
+fun CharSequence.truncate(limit: Int): CharSequence {
     return if (length > limit) {
         val truncated = take(limit)
         val remainingCharacters = length - limit

--- a/app/src/main/java/com/philkes/notallyx/utils/Operations.kt
+++ b/app/src/main/java/com/philkes/notallyx/utils/Operations.kt
@@ -41,7 +41,6 @@ object Operations {
 
     private const val TAG = "Operations"
 
-    const val extraCharSequence = "com.philkes.notallyx.extra.charSequence"
 
     fun getLastExceptionLog(app: Application): String? {
         val logFile = getLog(app)
@@ -98,13 +97,13 @@ object Operations {
     }
 
     fun shareNote(context: Context, title: String, body: CharSequence) {
-        val text = body.toString()
+        val text = body.truncate(150_000)
+
         val intent =
             Intent(Intent.ACTION_SEND)
                 .apply {
                     type = "text/plain"
-                    putExtra(extraCharSequence, body)
-                    putExtra(Intent.EXTRA_TEXT, text)
+                    putExtra(Intent.EXTRA_TEXT, text.toString())
                     putExtra(Intent.EXTRA_TITLE, title)
                     putExtra(Intent.EXTRA_SUBJECT, title)
                 }


### PR DESCRIPTION
Fixes #243 

There seems to be size limit for the payload of a `ACTION_SEND` intent, at 1MB, but this does not directly correspond to the sent text size. 
This PR limits the amount of characters being send via the share action to 150000, which is a lot and well under the limitation.
I did not encounter any problems with notes below this. If a note is bigger than 150000 the send text is truncated to that maximum length (with "...more characters") at the end, but I doubt anyone will create notes that big instead of just splitting them.