### PR TITLE
Display entire interface in note's color

### DIFF
--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/main/MainActivity.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/main/MainActivity.kt
@@ -638,7 +638,7 @@ class MainActivity : LockedActivity<ActivityMainBinding>() {
             showAsAction: Int = MenuItem.SHOW_AS_ACTION_IF_ROOM
         ): MenuItem {
             return add(R.string.change_color, R.drawable.change_color, showAsAction) {
-                showColorSelectDialog { selectedColor -> model.colorBaseNote(selectedColor) }
+                showColorSelectDialog(null) { selectedColor -> model.colorBaseNote(selectedColor) }
             }
         }
 

--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/note/EditNoteActivity.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/note/EditNoteActivity.kt
@@ -39,6 +39,7 @@ import com.philkes.notallyx.presentation.activity.note.PickNoteActivity.Companio
 import com.philkes.notallyx.presentation.add
 import com.philkes.notallyx.presentation.addIconButton
 import com.philkes.notallyx.presentation.dp
+import com.philkes.notallyx.presentation.setControlsContrastColorForAllViews
 import com.philkes.notallyx.presentation.setOnNextAction
 import com.philkes.notallyx.presentation.showKeyboard
 import com.philkes.notallyx.presentation.showToast
@@ -125,7 +126,7 @@ class EditNoteActivity : EditActivity(Type.NOTE), AddNoteActions {
     }
 
     override fun selectSearchResult(resultPos: Int) {
-        if(resultPos < 0){
+        if (resultPos < 0) {
             binding.EnterBody.unselectHighlight()
             return
         }
@@ -285,7 +286,7 @@ class EditNoteActivity : EditActivity(Type.NOTE), AddNoteActions {
         binding.BottomAppBarLeft.apply {
             removeAllViews()
             addIconButton(R.string.add_item, R.drawable.add, marginStart = 0) {
-                AddNoteBottomSheet(this@EditNoteActivity)
+                AddNoteBottomSheet(this@EditNoteActivity, colorInt)
                     .show(supportFragmentManager, AddNoteBottomSheet.TAG)
             }
             updateLayoutParams<ConstraintLayout.LayoutParams> { endToStart = -1 }
@@ -295,10 +296,12 @@ class EditNoteActivity : EditActivity(Type.NOTE), AddNoteActions {
                     }
                     .apply { isEnabled = binding.EnterBody.isActionModeOn }
         }
+        setBottomAppBarColor(colorInt)
     }
 
     private fun initBottomTextFormattingMenu() {
         binding.BottomAppBarCenter.visibility = GONE
+        val extractColor = colorInt
         binding.BottomAppBarRight.apply {
             removeAllViews()
             addView(
@@ -311,6 +314,8 @@ class EditNoteActivity : EditActivity(Type.NOTE), AddNoteActions {
                         marginEnd = 0
                         marginStart = 10.dp(context)
                     }
+                    setControlsContrastColorForAllViews(extractColor)
+                    setBackgroundColor(0)
                 }
             )
         }
@@ -323,7 +328,7 @@ class EditNoteActivity : EditActivity(Type.NOTE), AddNoteActions {
             val layout = BottomTextFormattingMenuBinding.inflate(layoutInflater, this, false)
             layout.RecyclerView.apply {
                 textFormattingAdapter =
-                    TextFormattingAdapter(this@EditNoteActivity, binding.EnterBody)
+                    TextFormattingAdapter(this@EditNoteActivity, binding.EnterBody, colorInt)
                 adapter = textFormattingAdapter
                 layoutManager = LinearLayoutManager(context, LinearLayoutManager.HORIZONTAL, false)
             }

--- a/app/src/main/java/com/philkes/notallyx/presentation/view/main/BaseNoteVH.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/view/main/BaseNoteVH.kt
@@ -30,6 +30,7 @@ import com.philkes.notallyx.databinding.RecyclerBaseNoteBinding
 import com.philkes.notallyx.presentation.applySpans
 import com.philkes.notallyx.presentation.displayFormattedTimestamp
 import com.philkes.notallyx.presentation.dp
+import com.philkes.notallyx.presentation.extractColor
 import com.philkes.notallyx.presentation.getColorFromAttr
 import com.philkes.notallyx.presentation.getQuantityString
 import com.philkes.notallyx.presentation.setControlsContrastColorForAllViews
@@ -217,7 +218,7 @@ class BaseNoteVH(
                 setControlsContrastColorForAllViews(context.getColorFromAttr(R.attr.colorSurface))
             } else {
                 strokeColor = 0
-                val colorInt = Operations.extractColor(color, context)
+                val colorInt = context.extractColor(color)
                 setCardBackgroundColor(colorInt)
                 setControlsContrastColorForAllViews(colorInt)
             }

--- a/app/src/main/java/com/philkes/notallyx/presentation/view/main/ColorVH.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/view/main/ColorVH.kt
@@ -3,8 +3,8 @@ package com.philkes.notallyx.presentation.view.main
 import androidx.recyclerview.widget.RecyclerView
 import com.philkes.notallyx.data.model.Color
 import com.philkes.notallyx.databinding.RecyclerColorBinding
+import com.philkes.notallyx.presentation.extractColor
 import com.philkes.notallyx.presentation.view.misc.ItemListener
-import com.philkes.notallyx.utils.Operations
 
 class ColorVH(private val binding: RecyclerColorBinding, listener: ItemListener) :
     RecyclerView.ViewHolder(binding.root) {
@@ -14,7 +14,7 @@ class ColorVH(private val binding: RecyclerColorBinding, listener: ItemListener)
     }
 
     fun bind(color: Color) {
-        val value = Operations.extractColor(color, binding.root.context)
+        val value = binding.root.context.extractColor(color)
         binding.CardView.setCardBackgroundColor(value)
         binding.CardView.contentDescription = color.name
     }

--- a/app/src/main/java/com/philkes/notallyx/presentation/view/note/TextFormattingAdapter.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/view/note/TextFormattingAdapter.kt
@@ -6,11 +6,15 @@ import android.text.style.StrikethroughSpan
 import android.text.style.StyleSpan
 import android.text.style.TypefaceSpan
 import android.text.style.URLSpan
+import androidx.annotation.ColorInt
 import com.philkes.notallyx.R
 import com.philkes.notallyx.presentation.view.misc.StylableEditTextWithHistory
 
-class TextFormattingAdapter(context: Context, private val editText: StylableEditTextWithHistory) :
-    ToggleAdapter(mutableListOf()) {
+class TextFormattingAdapter(
+    context: Context,
+    private val editText: StylableEditTextWithHistory,
+    @ColorInt color: Int?,
+) : ToggleAdapter(mutableListOf(), color) {
 
     private var link: Toggle =
         Toggle(R.string.link, R.drawable.link, false) {

--- a/app/src/main/java/com/philkes/notallyx/presentation/view/note/ToggleAdapter.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/view/note/ToggleAdapter.kt
@@ -2,13 +2,16 @@ package com.philkes.notallyx.presentation.view.note
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import androidx.annotation.ColorInt
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import androidx.recyclerview.widget.RecyclerView
 import com.philkes.notallyx.databinding.RecyclerToggleBinding
 
-open class ToggleAdapter(protected val toggles: MutableList<Toggle>) :
-    RecyclerView.Adapter<ToggleVH>() {
+open class ToggleAdapter(
+    protected val toggles: MutableList<Toggle>,
+    @ColorInt private val color: Int?,
+) : RecyclerView.Adapter<ToggleVH>() {
 
     override fun getItemCount() = toggles.size
 
@@ -20,7 +23,7 @@ open class ToggleAdapter(protected val toggles: MutableList<Toggle>) :
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ToggleVH {
         val inflater = LayoutInflater.from(parent.context)
         val binding = RecyclerToggleBinding.inflate(inflater, parent, false)
-        return ToggleVH(binding)
+        return ToggleVH(binding, color)
     }
 }
 

--- a/app/src/main/java/com/philkes/notallyx/presentation/view/note/ToggleVH.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/view/note/ToggleVH.kt
@@ -1,9 +1,12 @@
 package com.philkes.notallyx.presentation.view.note
 
+import androidx.annotation.ColorInt
 import androidx.recyclerview.widget.RecyclerView
 import com.philkes.notallyx.databinding.RecyclerToggleBinding
+import com.philkes.notallyx.presentation.setControlsContrastColorForAllViews
 
-class ToggleVH(private val binding: RecyclerToggleBinding) : RecyclerView.ViewHolder(binding.root) {
+class ToggleVH(private val binding: RecyclerToggleBinding, @ColorInt private val color: Int?) :
+    RecyclerView.ViewHolder(binding.root) {
 
     fun bind(toggle: Toggle) {
         binding.root.apply {
@@ -11,6 +14,7 @@ class ToggleVH(private val binding: RecyclerToggleBinding) : RecyclerView.ViewHo
             contentDescription = context.getString(toggle.titleResId)
             setOnClickListener { toggle.onToggle(toggle) }
             isChecked = toggle.checked
+            color?.let { setControlsContrastColorForAllViews(it, overwriteBackground = false) }
         }
     }
 }

--- a/app/src/main/java/com/philkes/notallyx/presentation/view/note/action/ActionBottomSheet.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/view/note/action/ActionBottomSheet.kt
@@ -6,6 +6,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.LinearLayout
+import androidx.annotation.ColorInt
 import androidx.core.content.ContextCompat
 import com.google.android.material.bottomsheet.BottomSheetBehavior.STATE_HIDDEN
 import com.google.android.material.bottomsheet.BottomSheetDialog
@@ -14,10 +15,15 @@ import com.philkes.notallyx.R
 import com.philkes.notallyx.databinding.BottomSheetActionBinding
 import com.philkes.notallyx.presentation.dp
 import com.philkes.notallyx.presentation.getColorFromAttr
+import com.philkes.notallyx.presentation.isLightColor
+import com.philkes.notallyx.presentation.setControlsContrastColorForAllViews
+import com.philkes.notallyx.presentation.setLightStatusAndNavBar
 
 /** Helper to create [BottomSheetDialogFragment] to display actions. */
-open class ActionBottomSheet(private val actions: Collection<Action>) :
-    BottomSheetDialogFragment() {
+open class ActionBottomSheet(
+    private val actions: Collection<Action>,
+    @ColorInt private val color: Int? = null,
+) : BottomSheetDialogFragment() {
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -67,13 +73,26 @@ open class ActionBottomSheet(private val actions: Collection<Action>) :
                     }
                 }
             view.addView(textView)
+            color?.let {
+                view.apply {
+                    setBackgroundColor(it)
+                    setControlsContrastColorForAllViews(it, overwriteBackground = false)
+                }
+            }
         }
 
         return view
     }
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-        return BottomSheetDialog(requireContext(), R.style.ThemeOverlay_App_BottomSheetDialog)
+        val dialog = BottomSheetDialog(requireContext(), R.style.ThemeOverlay_App_BottomSheetDialog)
+        color?.let {
+            dialog.window?.apply {
+                navigationBarColor = it
+                setLightStatusAndNavBar(it.isLightColor())
+            }
+        }
+        return dialog
     }
 
     private fun BottomSheetDialogFragment.hide() {

--- a/app/src/main/java/com/philkes/notallyx/presentation/view/note/action/AddBottomSheet.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/view/note/action/AddBottomSheet.kt
@@ -1,10 +1,12 @@
 package com.philkes.notallyx.presentation.view.note.action
 
 import android.os.Build
+import androidx.annotation.ColorInt
 import com.philkes.notallyx.R
 
 /** BottomSheet inside note for adding files, recording audio. */
-class AddBottomSheet(callbacks: AddActions) : ActionBottomSheet(createActions(callbacks)) {
+class AddBottomSheet(callbacks: AddActions, @ColorInt color: Int?) :
+    ActionBottomSheet(createActions(callbacks), color) {
 
     companion object {
         const val TAG = "AddBottomSheet"

--- a/app/src/main/java/com/philkes/notallyx/presentation/view/note/action/AddNoteBottomSheet.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/view/note/action/AddNoteBottomSheet.kt
@@ -1,9 +1,11 @@
 package com.philkes.notallyx.presentation.view.note.action
 
+import androidx.annotation.ColorInt
 import com.philkes.notallyx.R
 
 /** BottomSheet inside text note for adding files, recording audio. */
-class AddNoteBottomSheet(callbacks: AddNoteActions) : ActionBottomSheet(createActions(callbacks)) {
+class AddNoteBottomSheet(callbacks: AddNoteActions, @ColorInt color: Int?) :
+    ActionBottomSheet(createActions(callbacks), color) {
 
     companion object {
         const val TAG = "AddNoteBottomSheet"

--- a/app/src/main/java/com/philkes/notallyx/presentation/view/note/action/MoreListBottomSheet.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/view/note/action/MoreListBottomSheet.kt
@@ -1,12 +1,14 @@
 package com.philkes.notallyx.presentation.view.note.action
 
+import androidx.annotation.ColorInt
 import com.philkes.notallyx.R
 
 /** BottomSheet inside list-note for all common note actions and list-item actions. */
 class MoreListBottomSheet(
     callbacks: MoreListActions,
     additionalActions: Collection<Action> = listOf(),
-) : ActionBottomSheet(createActions(callbacks, additionalActions)) {
+    @ColorInt color: Int?,
+) : ActionBottomSheet(createActions(callbacks, additionalActions), color) {
 
     companion object {
         const val TAG = "MoreListBottomSheet"

--- a/app/src/main/java/com/philkes/notallyx/presentation/view/note/action/MoreNoteBottomSheet.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/view/note/action/MoreNoteBottomSheet.kt
@@ -1,12 +1,14 @@
 package com.philkes.notallyx.presentation.view.note.action
 
+import androidx.annotation.ColorInt
 import com.philkes.notallyx.R
 
 /** BottomSheet inside list-note for all common note actions. */
 class MoreNoteBottomSheet(
     callbacks: MoreActions,
     additionalActions: Collection<Action> = listOf(),
-) : ActionBottomSheet(createActions(callbacks, additionalActions)) {
+    @ColorInt color: Int?,
+) : ActionBottomSheet(createActions(callbacks, additionalActions), color) {
 
     companion object {
         const val TAG = "MoreNoteBottomSheet"

--- a/app/src/main/java/com/philkes/notallyx/presentation/view/note/audio/AudioAdapter.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/view/note/audio/AudioAdapter.kt
@@ -2,6 +2,7 @@ package com.philkes.notallyx.presentation.view.note.audio
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import androidx.annotation.ColorInt
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import com.philkes.notallyx.data.model.Audio
@@ -11,11 +12,18 @@ import java.text.DateFormat
 class AudioAdapter(private val onClick: (position: Int) -> Unit) :
     ListAdapter<Audio, AudioVH>(DiffCallback) {
 
+    @ColorInt private var color: Int? = null
+
+    fun setColor(@ColorInt colorInt: Int) {
+        color = colorInt
+        notifyDataSetChanged()
+    }
+
     private val formatter = DateFormat.getDateTimeInstance(DateFormat.FULL, DateFormat.SHORT)
 
     override fun onBindViewHolder(holder: AudioVH, position: Int) {
         val audio = getItem(position)
-        holder.bind(audio)
+        holder.bind(audio, color)
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): AudioVH {

--- a/app/src/main/java/com/philkes/notallyx/presentation/view/note/audio/AudioVH.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/view/note/audio/AudioVH.kt
@@ -4,6 +4,7 @@ import android.text.format.DateUtils
 import androidx.recyclerview.widget.RecyclerView
 import com.philkes.notallyx.data.model.Audio
 import com.philkes.notallyx.databinding.RecyclerAudioBinding
+import com.philkes.notallyx.presentation.setControlsContrastColorForAllViews
 import java.text.DateFormat
 
 class AudioVH(
@@ -16,8 +17,11 @@ class AudioVH(
         binding.root.setOnClickListener { onClick(adapterPosition) }
     }
 
-    fun bind(audio: Audio) {
-        binding.Date.text = formatter.format(audio.timestamp)
-        binding.Length.text = audio.duration?.let { DateUtils.formatElapsedTime(it / 1000) } ?: "-"
+    fun bind(audio: Audio, color: Int?) {
+        binding.apply {
+            Date.text = formatter.format(audio.timestamp)
+            Length.text = audio.duration?.let { DateUtils.formatElapsedTime(it / 1000) } ?: "-"
+            color?.let { root.setControlsContrastColorForAllViews(it) }
+        }
     }
 }

--- a/app/src/main/java/com/philkes/notallyx/presentation/view/note/preview/PreviewFileAdapter.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/view/note/preview/PreviewFileAdapter.kt
@@ -2,6 +2,7 @@ package com.philkes.notallyx.presentation.view.note.preview
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import androidx.annotation.ColorInt
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import com.philkes.notallyx.data.model.FileAttachment
@@ -12,9 +13,16 @@ class PreviewFileAdapter(
     private val onLongClick: (fileAttachment: FileAttachment) -> Boolean,
 ) : ListAdapter<FileAttachment, PreviewFileVH>(DiffCallback) {
 
+    @ColorInt private var color: Int? = null
+
+    fun setColor(@ColorInt colorInt: Int) {
+        color = colorInt
+        notifyDataSetChanged()
+    }
+
     override fun onBindViewHolder(holder: PreviewFileVH, position: Int) {
         val fileAttachment = getItem(position)
-        holder.bind(fileAttachment)
+        holder.bind(fileAttachment, color)
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): PreviewFileVH {

--- a/app/src/main/java/com/philkes/notallyx/presentation/view/note/preview/PreviewFileVH.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/view/note/preview/PreviewFileVH.kt
@@ -4,6 +4,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.philkes.notallyx.R
 import com.philkes.notallyx.data.model.FileAttachment
 import com.philkes.notallyx.databinding.RecyclerPreviewFileBinding
+import com.philkes.notallyx.presentation.setControlsContrastColorForAllViews
 
 class PreviewFileVH(
     private val binding: RecyclerPreviewFileBinding,
@@ -18,10 +19,11 @@ class PreviewFileVH(
         }
     }
 
-    fun bind(fileAttachment: FileAttachment) {
+    fun bind(fileAttachment: FileAttachment, color: Int?) {
         binding.FileName.apply {
             text = fileAttachment.originalName
             setChipIconResource(getIconForMimeType(fileAttachment.mimeType))
+            color?.let { setControlsContrastColorForAllViews(it) }
         }
     }
 

--- a/app/src/main/java/com/philkes/notallyx/utils/Operations.kt
+++ b/app/src/main/java/com/philkes/notallyx/utils/Operations.kt
@@ -27,6 +27,7 @@ import com.philkes.notallyx.data.model.ListItem
 import com.philkes.notallyx.databinding.LabelBinding
 import com.philkes.notallyx.presentation.dp
 import com.philkes.notallyx.presentation.getColorFromAttr
+import com.philkes.notallyx.presentation.setControlsContrastColorForAllViews
 import com.philkes.notallyx.presentation.showToast
 import com.philkes.notallyx.presentation.viewmodel.preference.TextSize
 import java.io.File
@@ -40,7 +41,6 @@ import java.text.DateFormat
 object Operations {
 
     private const val TAG = "Operations"
-
 
     fun getLastExceptionLog(app: Application): String? {
         val logFile = getLog(app)
@@ -124,6 +124,7 @@ object Operations {
         labels: List<String>,
         textSize: TextSize,
         paddingTop: Boolean,
+        color: Int? = null,
     ) {
         if (labels.isEmpty()) {
             group.visibility = View.GONE
@@ -140,6 +141,7 @@ object Operations {
                     background = getOutlinedDrawable(group.context)
                     setTextSize(TypedValue.COMPLEX_UNIT_SP, labelSize)
                     text = label
+                    color?.let { setControlsContrastColorForAllViews(it) }
                 }
             }
         }

--- a/app/src/main/res/color/toggle_background.xml
+++ b/app/src/main/res/color/toggle_background.xml
@@ -1,0 +1,4 @@
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+  <item android:state_checked="false" android:color="@color/Transparent" />
+  <item android:state_checked="true" android:color="@color/TextDarkLight" />
+</selector>

--- a/app/src/main/res/layout/activity_edit.xml
+++ b/app/src/main/res/layout/activity_edit.xml
@@ -42,6 +42,7 @@
               android:paddingTop="10dp"
               android:paddingBottom="10dp"
               android:paddingEnd="10dp"
+              android:textIsSelectable="false"
               android:textAppearance="?attr/textAppearanceBody1"
               android:visibility="gone" />
         </LinearLayout>
@@ -176,6 +177,7 @@
                     android:text="@string/add_item"
                     android:textAppearance="?attr/textAppearanceSubtitle2"
                     android:textColor="?android:textColorHint"
+                    android:textIsSelectable="false"
                     app:drawableStartCompat="@drawable/add" />
 
                 <TextView

--- a/app/src/main/res/layout/bottom_sheet_action.xml
+++ b/app/src/main/res/layout/bottom_sheet_action.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <TextView xmlns:android="http://schemas.android.com/apk/res/android"
   style="@style/BottomSheetText"
+  android:backgroundTint="@color/Transparent"
   android:clickable="true"
   android:layout_width="match_parent"
   android:layout_height="wrap_content" />

--- a/app/src/main/res/layout/label.xml
+++ b/app/src/main/res/layout/label.xml
@@ -5,5 +5,6 @@
     android:includeFontPadding="false"
     android:paddingHorizontal="12dp"
     android:paddingVertical="6dp"
+    android:textIsSelectable="false"
     android:textAppearance="?attr/textAppearanceBodyMedium"
     android:textColor="?attr/colorControlNormal" />

--- a/app/src/main/res/layout/recycler_base_note.xml
+++ b/app/src/main/res/layout/recycler_base_note.xml
@@ -13,9 +13,7 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:paddingBottom="16dp"
-        android:paddingStart="16dp"
-        android:paddingEnd="16dp">
+        android:paddingBottom="16dp">
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/ImageLayout"
@@ -43,6 +41,8 @@
                 android:visibility="visible"
                 app:chipIcon="@drawable/add_images"
                 app:chipStartPadding="8dp"
+                android:paddingStart="16dp"
+                android:paddingEnd="16dp"
                 app:layout_constraintEnd_toEndOf="@id/ImageView"
                 app:layout_constraintTop_toTopOf="@id/ImageView"
                 app:textStartPadding="2dp"
@@ -57,7 +57,10 @@
             android:layout_width="match_parent"
             android:layout_height="0dp"
             android:gravity="center"
-          android:clickable="false"
+            android:clickable="false"
+            android:textIsSelectable="false"
+            android:paddingStart="16dp"
+            android:paddingEnd="16dp"
             android:text="@string/cant_load_image"
             android:textAppearance="?attr/textAppearanceBodyMedium"
             app:layout_constraintDimensionRatio="4:3"
@@ -78,6 +81,9 @@
             android:textAppearance="?attr/textAppearanceBodyLarge"
             android:textColor="?attr/colorOnSurface"
             android:ellipsize="end"
+            android:textIsSelectable="false"
+            android:paddingStart="16dp"
+            android:paddingEnd="16dp"
             app:layout_constraintTop_toBottomOf="@id/Space" />
 
         <TextView
@@ -85,6 +91,9 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:paddingBottom="6dp"
+            android:textIsSelectable="false"
+            android:paddingStart="16dp"
+            android:paddingEnd="16dp"
             app:layout_constraintTop_toBottomOf="@id/Title" />
 
         <LinearLayout
@@ -94,6 +103,8 @@
             android:orientation="horizontal"
             android:paddingTop="0dp"
             android:paddingBottom="4dp"
+            android:paddingStart="16dp"
+            android:paddingEnd="16dp"
             app:layout_constraintTop_toBottomOf="@id/Date"
             >
             <com.google.android.material.chip.Chip
@@ -130,6 +141,9 @@
             android:layout_height="wrap_content"
             android:lineSpacingMultiplier="1.1"
             android:ellipsize="end"
+            android:textIsSelectable="false"
+            android:paddingStart="16dp"
+            android:paddingEnd="16dp"
             app:layout_constraintTop_toBottomOf="@id/FileViewLayout" />
 
         <LinearLayout
@@ -137,10 +151,55 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="vertical"
+            android:paddingStart="16dp"
+            android:paddingEnd="16dp"
             app:layout_constraintTop_toBottomOf="@id/Note">
 
             <TextView
                 style="@style/FileChip.ListItem"
+                android:textIsSelectable="false"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+
+            <TextView
+                style="@style/FileChip.ListItem"
+                android:textIsSelectable="false"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+
+            <TextView
+                style="@style/FileChip.ListItem"
+                android:textIsSelectable="false"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+
+            <TextView
+                style="@style/FileChip.ListItem"
+                android:textIsSelectable="false"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+
+            <TextView
+                style="@style/FileChip.ListItem"
+                android:textIsSelectable="false"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+
+            <TextView
+                style="@style/FileChip.ListItem"
+                android:textIsSelectable="false"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+
+            <TextView
+                style="@style/FileChip.ListItem"
+                android:textIsSelectable="false"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+
+            <TextView
+                style="@style/FileChip.ListItem"
+                android:textIsSelectable="false"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content" />
 
@@ -151,47 +210,14 @@
 
             <TextView
                 style="@style/FileChip.ListItem"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content" />
-
-            <TextView
-                style="@style/FileChip.ListItem"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content" />
-
-            <TextView
-                style="@style/FileChip.ListItem"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content" />
-
-            <TextView
-                style="@style/FileChip.ListItem"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content" />
-
-            <TextView
-                style="@style/FileChip.ListItem"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content" />
-
-            <TextView
-                style="@style/FileChip.ListItem"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content" />
-
-            <TextView
-                style="@style/FileChip.ListItem"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content" />
-
-            <TextView
-                style="@style/FileChip.ListItem"
+                android:textIsSelectable="false"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content" />
 
             <TextView
                 android:id="@+id/ItemsRemaining"
                 style="@style/FileChip.ListItem"
+                android:textIsSelectable="false"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 app:drawableStartCompat="@drawable/add_16" />
@@ -203,6 +229,8 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:stateListAnimator="@null"
+            android:paddingStart="16dp"
+            android:paddingEnd="16dp"
             app:layout_constraintTop_toBottomOf="@id/LinearLayout" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/recycler_toggle.xml
+++ b/app/src/main/res/layout/recycler_toggle.xml
@@ -4,6 +4,7 @@
   xmlns:android="http://schemas.android.com/apk/res/android"
   android:id="@+id/Button"
   style="?attr/materialIconButtonStyle"
+  android:backgroundTint="@color/toggle_background"
   android:layout_width="wrap_content"
   android:layout_height="match_parent"
   android:checkable="true"

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -146,6 +146,7 @@
 
     <color name="TextLight">#F1F0F7</color>
     <color name="TextDark">#1A1B21</color>
+    <color name="TextDarkLight">#261A1B21</color>
 
     <!-- Note Colors -->
     <color name="Coral">#FAAFA9</color>


### PR DESCRIPTION
Closes #264 

Re-colors Toolbars, BottomAppBar, BottomSheets, EditText cursor + selection drawables, navigation + status bar, Searchbar according to note's color

[notallyx_issues_264.webm](https://github.com/user-attachments/assets/0be42f8c-f113-4902-827a-e7de4ee24bee)
