### PR TITLE
Fix do not checkAutoSave if empty note was deleted

### DIFF
--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/note/EditActivity.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/note/EditActivity.kt
@@ -106,7 +106,7 @@ abstract class EditActivity(private val type: Type) :
     override fun finish() {
         lifecycleScope.launch(Dispatchers.Main) {
             if (notallyModel.isEmpty()) {
-                notallyModel.deleteBaseNote()
+                notallyModel.deleteBaseNote(checkAutoSave = false)
             } else if (notallyModel.isModified()) {
                 saveNote()
             }

--- a/app/src/main/java/com/philkes/notallyx/presentation/viewmodel/NotallyModel.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/viewmodel/NotallyModel.kt
@@ -260,7 +260,7 @@ class NotallyModel(private val app: Application) : AndroidViewModel(app) {
         return baseNote.copy(id = id)
     }
 
-    suspend fun deleteBaseNote() {
+    suspend fun deleteBaseNote(checkAutoSave: Boolean = true) {
         app.cancelNoteReminders(listOf(NoteReminder(id, reminders.value)))
         withContext(Dispatchers.IO) { baseNoteDao.delete(id) }
         WidgetProvider.sendBroadcast(app, longArrayOf(id))
@@ -268,7 +268,9 @@ class NotallyModel(private val app: Application) : AndroidViewModel(app) {
         if (attachments.isNotEmpty()) {
             withContext(Dispatchers.IO) { app.deleteAttachments(attachments) }
         }
-        app.checkAutoSave(preferences, forceFullBackup = true)
+        if (checkAutoSave) {
+            app.checkAutoSave(preferences, forceFullBackup = true)
+        }
     }
 
     fun setItems(items: List<ListItem>) {


### PR DESCRIPTION
Fixes #288 

When you exit from an empty note, it is deleted. Skip checking for auto-save when that happens