### PR TITLE
Re-set cursor and scroll position on orientation change

### DIFF
--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/main/fragment/NotallyFragment.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/main/fragment/NotallyFragment.kt
@@ -53,6 +53,20 @@ abstract class NotallyFragment : Fragment(), ItemListener {
         notesAdapter = null
     }
 
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        val layoutManager = binding?.RecyclerView?.layoutManager as? LinearLayoutManager
+        if (layoutManager != null) {
+            val firstVisiblePosition = layoutManager.findFirstVisibleItemPosition()
+            if (firstVisiblePosition != RecyclerView.NO_POSITION) {
+                val firstVisibleView = layoutManager.findViewByPosition(firstVisiblePosition)
+                val offset = firstVisibleView?.top ?: 0
+                outState.putInt(EXTRA_SCROLL_POS, firstVisiblePosition)
+                outState.putInt(EXTRA_SCROLL_OFFSET, offset)
+            }
+        }
+    }
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         binding?.ImageView?.setImageResource(getBackground())
 
@@ -61,6 +75,17 @@ abstract class NotallyFragment : Fragment(), ItemListener {
         setupObserver()
 
         setupActivityResultLaunchers()
+
+        savedInstanceState?.let { bundle ->
+            val scrollPosition = bundle.getInt(EXTRA_SCROLL_POS, -1)
+            val scrollOffset = bundle.getInt(EXTRA_SCROLL_OFFSET, 0)
+            if (scrollPosition > -1) {
+                binding?.RecyclerView?.post {
+                    val layoutManager = binding?.RecyclerView?.layoutManager as? LinearLayoutManager
+                    layoutManager?.scrollToPositionWithOffset(scrollPosition, scrollOffset)
+                }
+            }
+        }
     }
 
     private fun setupActivityResultLaunchers() {
@@ -235,5 +260,10 @@ abstract class NotallyFragment : Fragment(), ItemListener {
 
     open fun prepareNewNoteIntent(intent: Intent): Intent {
         return intent
+    }
+
+    companion object {
+        private const val EXTRA_SCROLL_POS = "notallyx.intent.extra.SCROLL_POS"
+        private const val EXTRA_SCROLL_OFFSET = "notallyx.intent.extra.SCROLL_OFFSET"
     }
 }

--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/note/EditActivity.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/note/EditActivity.kt
@@ -16,11 +16,13 @@ import android.view.View
 import android.view.View.GONE
 import android.view.ViewGroup.LayoutParams
 import android.view.ViewGroup.VISIBLE
+import android.view.inputmethod.InputMethodManager
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.annotation.ColorInt
 import androidx.annotation.RequiresApi
+import androidx.core.content.ContextCompat
 import androidx.core.content.IntentCompat
 import androidx.core.view.isVisible
 import androidx.core.widget.doAfterTextChanged
@@ -92,16 +94,16 @@ abstract class EditActivity(private val type: Type) :
     private lateinit var attachFilesActivityResultLauncher: ActivityResultLauncher<Intent>
 
     private lateinit var pinMenuItem: MenuItem
-
     protected var search = Search()
 
     internal val notallyModel: NotallyModel by viewModels()
-    internal lateinit var changeHistory: ChangeHistory
 
+    internal lateinit var changeHistory: ChangeHistory
     protected var undo: View? = null
     protected var redo: View? = null
 
     protected var colorInt: Int = -1
+    protected var inputMethodManager: InputMethodManager? = null
 
     override fun finish() {
         lifecycleScope.launch(Dispatchers.Main) {
@@ -130,6 +132,8 @@ abstract class EditActivity(private val type: Type) :
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        inputMethodManager =
+            ContextCompat.getSystemService(baseContext, InputMethodManager::class.java)
         notallyModel.type = type
         initialiseBinding()
         setContentView(binding.root)
@@ -152,7 +156,7 @@ abstract class EditActivity(private val type: Type) :
 
             setupToolbars()
             setupListeners()
-            setStateFromModel()
+            setStateFromModel(savedInstanceState)
 
             configureUI()
             binding.ScrollView.apply {
@@ -482,7 +486,7 @@ abstract class EditActivity(private val type: Type) :
         }
     }
 
-    open fun setStateFromModel() {
+    open fun setStateFromModel(savedInstanceState: Bundle?) {
         val (date, datePrefixResId) =
             when (preferences.notesSorting.value.sortedBy) {
                 NotesSortBy.CREATION_DATE -> Pair(notallyModel.timestamp, R.string.creation_date)

--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/note/EditNoteActivity.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/note/EditNoteActivity.kt
@@ -78,6 +78,14 @@ class EditNoteActivity : EditActivity(Type.NOTE), AddNoteActions {
         setupActivityResultLaunchers()
     }
 
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        outState.apply {
+            putInt(EXTRA_SELECTION_START, binding.EnterBody.selectionStart)
+            putInt(EXTRA_SELECTION_END, binding.EnterBody.selectionEnd)
+        }
+    }
+
     private fun setupActivityResultLaunchers() {
         pickNoteNewActivityResultLauncher =
             registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
@@ -146,9 +154,16 @@ class EditNoteActivity : EditActivity(Type.NOTE), AddNoteActions {
         }
     }
 
-    override fun setStateFromModel() {
-        super.setStateFromModel()
+    override fun setStateFromModel(savedInstanceState: Bundle?) {
+        super.setStateFromModel(savedInstanceState)
         updateEditText()
+        savedInstanceState?.let {
+            val selectionStart = it.getInt(EXTRA_SELECTION_START, -1)
+            val selectionEnd = it.getInt(EXTRA_SELECTION_END, -1)
+            if (selectionStart > -1) {
+                binding.EnterBody.focusAndSelect(selectionStart, selectionEnd)
+            }
+        }
     }
 
     private fun updateEditText() {
@@ -446,5 +461,10 @@ class EditNoteActivity : EditActivity(Type.NOTE), AddNoteActions {
         val noteType = Type.valueOf(this.getStringExtra(EXTRA_PICKED_NOTE_TYPE)!!)
         val noteUrl = noteId.createNoteUrl(noteType)
         return Triple(noteTitle, noteUrl, emptyTitle)
+    }
+
+    companion object {
+        private const val EXTRA_SELECTION_START = "notallyx.intent.extra.EXTRA_SELECTION_START"
+        private const val EXTRA_SELECTION_END = "notallyx.intent.extra.EXTRA_SELECTION_END"
     }
 }

--- a/app/src/main/java/com/philkes/notallyx/presentation/view/misc/EditTextWithWatcher.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/view/misc/EditTextWithWatcher.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.text.Editable
 import android.text.TextWatcher
 import android.util.AttributeSet
+import android.view.inputmethod.InputMethodManager
 import androidx.appcompat.widget.AppCompatEditText
 import com.philkes.notallyx.presentation.clone
 
@@ -54,5 +55,17 @@ open class EditTextWithWatcher(context: Context, attrs: AttributeSet) :
 
     fun changeText(callback: (text: Editable) -> Unit): Pair<Editable, Editable> {
         return applyWithoutTextWatcher { callback(super.getText()!!) }
+    }
+
+    fun focusAndSelect(
+        start: Int = selectionStart,
+        end: Int = selectionEnd,
+        inputMethodManager: InputMethodManager? = null,
+    ) {
+        requestFocus()
+        if (start > -1) {
+            setSelection(start, if (end < 0) start else end)
+        }
+        inputMethodManager?.showSoftInput(this, InputMethodManager.SHOW_IMPLICIT)
     }
 }

--- a/app/src/main/java/com/philkes/notallyx/presentation/view/note/listitem/ListItemVH.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/view/note/listitem/ListItemVH.kt
@@ -117,13 +117,10 @@ class ListItemVH(
 
     fun focusEditText(
         selectionStart: Int = binding.EditText.text!!.length,
-        inputMethodManager: InputMethodManager,
+        selectionEnd: Int = selectionStart,
+        inputMethodManager: InputMethodManager?,
     ) {
-        binding.EditText.apply {
-            requestFocus()
-            setSelection(selectionStart)
-            inputMethodManager.showSoftInput(this, InputMethodManager.SHOW_IMPLICIT)
-        }
+        binding.EditText.focusAndSelect(selectionStart, selectionEnd, inputMethodManager)
     }
 
     private fun updateDeleteButton(item: ListItem, position: Int) {
@@ -211,5 +208,9 @@ class ListItemVH(
                 }
         }
         return containsLines
+    }
+
+    fun getSelection(): Pair<Int, Int> {
+        return Pair(binding.EditText.selectionStart, binding.EditText.selectionEnd)
     }
 }


### PR DESCRIPTION
Fixes #293 

- On orientation change the cursor and scroll posoitions are restored
- This also includes scroll position in any notes overview Views