### PR TITLE
Increase input dialog sizes to fit large keyboards

### DIFF
--- a/app/src/main/java/com/philkes/notallyx/presentation/UiExtensions.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/UiExtensions.kt
@@ -32,6 +32,7 @@ import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
 import android.view.Window
+import android.view.WindowManager
 import android.view.WindowManager.LayoutParams.SOFT_INPUT_STATE_VISIBLE
 import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.InputMethodManager
@@ -451,7 +452,7 @@ fun Activity.checkNotificationPermission(
             if (shouldShowRequestPermissionRationale(permission)) {
                 MaterialAlertDialogBuilder(this)
                     .setMessage(R.string.please_grant_notally_notification)
-                    .addCancelButton()
+                    .setCancelButton()
                     .setPositiveButton(R.string.continue_) { _, _ ->
                         requestPermissions(arrayOf(permission), requestCode)
                     }
@@ -524,14 +525,30 @@ fun Activity.showColorSelectDialog(
     }
 }
 
-fun MaterialAlertDialogBuilder.showAndFocus(view: View, selectAll: Boolean = false): AlertDialog {
+fun MaterialAlertDialogBuilder.showAndFocus(
+    viewToFocus: View? = null,
+    selectAll: Boolean = false,
+    fullWidth: Boolean = false,
+): AlertDialog {
+    if (fullWidth) {
+        setBackgroundInsetEnd(0)
+        setBackgroundInsetStart(0)
+        setBackgroundInsetBottom(0)
+        setBackgroundInsetTop(0)
+    }
     return create().apply {
-        view.requestFocus()
-        if (view is EditText) {
+        viewToFocus?.requestFocus()
+        if (viewToFocus is EditText) {
             if (selectAll) {
-                view.selectAll()
+                viewToFocus.selectAll()
             }
             window?.setSoftInputMode(SOFT_INPUT_STATE_VISIBLE)
+        }
+        if (fullWidth) {
+            window?.setLayout(
+                WindowManager.LayoutParams.MATCH_PARENT,
+                WindowManager.LayoutParams.WRAP_CONTENT,
+            )
         }
         show()
     }
@@ -674,10 +691,8 @@ fun @receiver:ColorInt Int.isLightColor(): Boolean {
     return luminance > 0.5
 }
 
-fun MaterialAlertDialogBuilder.addCancelButton(): MaterialAlertDialogBuilder {
-    setNegativeButton(R.string.cancel, null)
-    return this
-}
+fun MaterialAlertDialogBuilder.setCancelButton(listener: DialogInterface.OnClickListener? = null) =
+    setNegativeButton(R.string.cancel, listener)
 
 fun Fragment.showDialog(
     messageResId: Int,
@@ -695,7 +710,7 @@ fun Context.showDialog(
     MaterialAlertDialogBuilder(this)
         .setMessage(messageResId)
         .setPositiveButton(positiveButtonTextResId, onPositiveButtonClickListener)
-        .addCancelButton()
+        .setCancelButton()
         .show()
 }
 

--- a/app/src/main/java/com/philkes/notallyx/presentation/UiExtensions.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/UiExtensions.kt
@@ -476,7 +476,7 @@ fun Activity.checkAlarmPermission(
         } else {
             MaterialAlertDialogBuilder(this)
                 .setMessage(R.string.please_grant_notally_alarm)
-                .addCancelButton()
+                .setCancelButton()
                 .setPositiveButton(R.string.continue_) { _, _ ->
                     val intent = Intent(Settings.ACTION_REQUEST_SCHEDULE_EXACT_ALARM)
                     intent.data = Uri.parse("package:$packageName")

--- a/app/src/main/java/com/philkes/notallyx/presentation/UiExtensions.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/UiExtensions.kt
@@ -528,9 +528,9 @@ fun Activity.showColorSelectDialog(
 fun MaterialAlertDialogBuilder.showAndFocus(
     viewToFocus: View? = null,
     selectAll: Boolean = false,
-    fullWidth: Boolean = false,
+    allowFullSize: Boolean = false,
 ): AlertDialog {
-    if (fullWidth) {
+    if (allowFullSize) {
         setBackgroundInsetEnd(0)
         setBackgroundInsetStart(0)
         setBackgroundInsetBottom(0)
@@ -544,7 +544,7 @@ fun MaterialAlertDialogBuilder.showAndFocus(
             }
             window?.setSoftInputMode(SOFT_INPUT_STATE_VISIBLE)
         }
-        if (fullWidth) {
+        if (allowFullSize) {
             window?.setLayout(
                 WindowManager.LayoutParams.MATCH_PARENT,
                 WindowManager.LayoutParams.WRAP_CONTENT,

--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/main/MainActivity.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/main/MainActivity.kt
@@ -53,6 +53,7 @@ import com.philkes.notallyx.presentation.add
 import com.philkes.notallyx.presentation.applySpans
 import com.philkes.notallyx.presentation.getQuantityString
 import com.philkes.notallyx.presentation.movedToResId
+import com.philkes.notallyx.presentation.setCancelButton
 import com.philkes.notallyx.presentation.showColorSelectDialog
 import com.philkes.notallyx.presentation.view.misc.MenuDialog
 import com.philkes.notallyx.presentation.view.misc.NotNullLiveData
@@ -284,7 +285,7 @@ class MainActivity : LockedActivity<ActivityMainBinding>() {
         MaterialAlertDialogBuilder(this)
             .setMessage(R.string.delete_selected_notes)
             .setPositiveButton(R.string.delete) { _, _ -> baseModel.deleteSelectedBaseNotes() }
-            .setNegativeButton(R.string.cancel, null)
+            .setCancelButton()
             .show()
     }
 
@@ -317,7 +318,7 @@ class MainActivity : LockedActivity<ActivityMainBinding>() {
 
         MaterialAlertDialogBuilder(this)
             .setTitle(R.string.labels)
-            .setNegativeButton(R.string.cancel, null)
+            .setCancelButton()
             .setMultiChoiceTriStateItems(this, labels, checkedPositions) { idx, state ->
                 checkedPositions[idx] = state
             }

--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/main/fragment/DeletedFragment.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/main/fragment/DeletedFragment.kt
@@ -8,6 +8,7 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.philkes.notallyx.R
 import com.philkes.notallyx.data.model.Folder
 import com.philkes.notallyx.presentation.add
+import com.philkes.notallyx.presentation.setCancelButton
 
 class DeletedFragment : NotallyFragment() {
 
@@ -24,7 +25,7 @@ class DeletedFragment : NotallyFragment() {
         MaterialAlertDialogBuilder(requireContext())
             .setMessage(R.string.delete_all_notes)
             .setPositiveButton(R.string.delete) { _, _ -> model.deleteAllTrashedBaseNotes() }
-            .setNegativeButton(R.string.cancel, null)
+            .setCancelButton()
             .show()
     }
 

--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/main/fragment/LabelsFragment.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/main/fragment/LabelsFragment.kt
@@ -18,6 +18,7 @@ import com.philkes.notallyx.databinding.DialogInputBinding
 import com.philkes.notallyx.databinding.FragmentNotesBinding
 import com.philkes.notallyx.presentation.activity.main.fragment.DisplayLabelFragment.Companion.EXTRA_DISPLAYED_LABEL
 import com.philkes.notallyx.presentation.add
+import com.philkes.notallyx.presentation.setCancelButton
 import com.philkes.notallyx.presentation.initListView
 import com.philkes.notallyx.presentation.showAndFocus
 import com.philkes.notallyx.presentation.showToast
@@ -116,7 +117,7 @@ class LabelsFragment : Fragment(), LabelListener {
         MaterialAlertDialogBuilder(requireContext())
             .setTitle(R.string.add_label)
             .setView(dialogBinding.root)
-            .setNegativeButton(R.string.cancel, null)
+            .setCancelButton()
             .setPositiveButton(R.string.save) { dialog, _ ->
                 val value = dialogBinding.EditText.text.toString().trim()
                 if (value.isNotEmpty()) {
@@ -138,7 +139,7 @@ class LabelsFragment : Fragment(), LabelListener {
             .setTitle(R.string.delete_label)
             .setMessage(R.string.your_notes_associated)
             .setPositiveButton(R.string.delete) { _, _ -> model.deleteLabel(value) }
-            .setNegativeButton(R.string.cancel, null)
+            .setCancelButton()
             .show()
     }
 
@@ -150,7 +151,7 @@ class LabelsFragment : Fragment(), LabelListener {
         MaterialAlertDialogBuilder(requireContext())
             .setView(dialogBinding.root)
             .setTitle(R.string.edit_label)
-            .setNegativeButton(R.string.cancel, null)
+            .setCancelButton()
             .setPositiveButton(R.string.save) { dialog, _ ->
                 val value = dialogBinding.EditText.text.toString().trim()
                 if (value.isNotEmpty()) {

--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/main/fragment/LabelsFragment.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/main/fragment/LabelsFragment.kt
@@ -18,8 +18,8 @@ import com.philkes.notallyx.databinding.DialogInputBinding
 import com.philkes.notallyx.databinding.FragmentNotesBinding
 import com.philkes.notallyx.presentation.activity.main.fragment.DisplayLabelFragment.Companion.EXTRA_DISPLAYED_LABEL
 import com.philkes.notallyx.presentation.add
-import com.philkes.notallyx.presentation.setCancelButton
 import com.philkes.notallyx.presentation.initListView
+import com.philkes.notallyx.presentation.setCancelButton
 import com.philkes.notallyx.presentation.showAndFocus
 import com.philkes.notallyx.presentation.showToast
 import com.philkes.notallyx.presentation.view.main.label.LabelAdapter
@@ -131,7 +131,7 @@ class LabelsFragment : Fragment(), LabelListener {
                     }
                 }
             }
-            .showAndFocus(dialogBinding.EditText)
+            .showAndFocus(dialogBinding.EditText, allowFullSize = true)
     }
 
     private fun confirmDeletion(value: String) {
@@ -168,6 +168,6 @@ class LabelsFragment : Fragment(), LabelListener {
                     }
                 }
             }
-            .showAndFocus(dialogBinding.EditText)
+            .showAndFocus(dialogBinding.EditText, allowFullSize = true)
     }
 }

--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/main/fragment/settings/PreferenceBindingExtensions.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/main/fragment/settings/PreferenceBindingExtensions.kt
@@ -18,8 +18,11 @@ import com.philkes.notallyx.databinding.DialogPreferenceBooleanBinding
 import com.philkes.notallyx.databinding.DialogTextInputBinding
 import com.philkes.notallyx.databinding.PreferenceBinding
 import com.philkes.notallyx.databinding.PreferenceSeekbarBinding
+import com.philkes.notallyx.databinding.TextInputDialogBinding
 import com.philkes.notallyx.presentation.addCancelButton
 import com.philkes.notallyx.presentation.checkedTag
+import com.philkes.notallyx.presentation.setCancelButton
+import com.philkes.notallyx.presentation.showAndFocus
 import com.philkes.notallyx.presentation.showToast
 import com.philkes.notallyx.presentation.view.misc.MenuDialog
 import com.philkes.notallyx.presentation.viewmodel.BaseNoteModel
@@ -58,7 +61,7 @@ inline fun <reified T> PreferenceBinding.setup(
                 val newValue = enumEntries[which]
                 onSave(newValue)
             }
-            .addCancelButton()
+            .setCancelButton()
             .show()
     }
 }
@@ -118,7 +121,7 @@ fun PreferenceBinding.setup(
                     }
                 }
             }
-            .addCancelButton()
+            .setCancelButton()
             .show()
     }
 }
@@ -175,7 +178,7 @@ fun PreferenceBinding.setup(
                     NotesSort(newSortBy, newSortDirection),
                 )
             }
-            .addCancelButton()
+            .setCancelButton()
             .show()
     }
 }
@@ -252,7 +255,7 @@ fun PreferenceBinding.setup(
                 }
             }
         val dialog =
-            MaterialAlertDialogBuilder(context).setView(layout.root).addCancelButton().show()
+            MaterialAlertDialogBuilder(context).setView(layout.root).setCancelButton().show()
         layout.apply {
             EnabledButton.setOnClickListener {
                 dialog.cancel()
@@ -350,12 +353,12 @@ fun PreferenceBinding.setupBackupPassword(
                 val updatedPassword = layout.InputText.text.toString()
                 onSave(updatedPassword)
             }
-            .addCancelButton()
+            .setCancelButton()
             .setNeutralButton(R.string.clear) { dialog, _ ->
                 dialog.cancel()
                 onSave(PASSWORD_EMPTY)
             }
-            .show()
+            .showAndFocus(fullWidth = true)
     }
 }
 

--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/main/fragment/settings/PreferenceBindingExtensions.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/main/fragment/settings/PreferenceBindingExtensions.kt
@@ -356,7 +356,7 @@ fun PreferenceBinding.setupBackupPassword(
                 dialog.cancel()
                 onSave(PASSWORD_EMPTY)
             }
-            .showAndFocus(fullWidth = true)
+            .showAndFocus(allowFullSize = true)
     }
 }
 

--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/main/fragment/settings/PreferenceBindingExtensions.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/main/fragment/settings/PreferenceBindingExtensions.kt
@@ -18,8 +18,6 @@ import com.philkes.notallyx.databinding.DialogPreferenceBooleanBinding
 import com.philkes.notallyx.databinding.DialogTextInputBinding
 import com.philkes.notallyx.databinding.PreferenceBinding
 import com.philkes.notallyx.databinding.PreferenceSeekbarBinding
-import com.philkes.notallyx.databinding.TextInputDialogBinding
-import com.philkes.notallyx.presentation.addCancelButton
 import com.philkes.notallyx.presentation.checkedTag
 import com.philkes.notallyx.presentation.setCancelButton
 import com.philkes.notallyx.presentation.showAndFocus
@@ -220,7 +218,7 @@ fun PreferenceBinding.setup(
                 val applyToNoteView = layout.ApplyToNoteView.isChecked
                 onSave(dateFormat, applyToNoteView)
             }
-            .addCancelButton()
+            .setCancelButton()
             .show()
     }
 }
@@ -301,7 +299,7 @@ fun PreferenceBinding.setupPeriodicBackup(
                 }
             }
         val dialog =
-            MaterialAlertDialogBuilder(context).setView(layout.root).addCancelButton().show()
+            MaterialAlertDialogBuilder(context).setView(layout.root).setCancelButton().show()
         layout.apply {
             EnabledButton.setOnClickListener {
                 dialog.cancel()

--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/main/fragment/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/main/fragment/settings/SettingsFragment.kt
@@ -439,7 +439,7 @@ class SettingsFragment : Fragment() {
                         }
                     }
                     .setNeutralButton(R.string.cancel) { dialog, _ -> dialog.cancel() }
-                    .showAndFocus(fullWidth = true)
+                    .showAndFocus(allowFullSize = true)
             }
             .setCancelButton()
             .show()

--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/main/fragment/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/main/fragment/settings/SettingsFragment.kt
@@ -29,9 +29,11 @@ import com.philkes.notallyx.data.imports.txt.APPLICATION_TEXT_MIME_TYPES
 import com.philkes.notallyx.data.model.toText
 import com.philkes.notallyx.databinding.DialogTextInputBinding
 import com.philkes.notallyx.databinding.FragmentSettingsBinding
-import com.philkes.notallyx.presentation.addCancelButton
+import com.philkes.notallyx.databinding.TextInputDialogBinding
+import com.philkes.notallyx.presentation.setCancelButton
 import com.philkes.notallyx.presentation.setupImportProgressDialog
 import com.philkes.notallyx.presentation.setupProgressDialog
+import com.philkes.notallyx.presentation.showAndFocus
 import com.philkes.notallyx.presentation.showDialog
 import com.philkes.notallyx.presentation.showToast
 import com.philkes.notallyx.presentation.view.misc.TextWithIconAdapter
@@ -206,7 +208,7 @@ class SettingsFragment : Fragment() {
                         val usedPassword = layout.InputText.text.toString()
                         model.importZipBackup(uri, usedPassword)
                     }
-                    .addCancelButton()
+                    .setCancelButton()
                     .show()
             }
         }
@@ -409,7 +411,7 @@ class SettingsFragment : Fragment() {
                                                 )
                                         }
                                     }
-                                    .addCancelButton()
+                                    .setCancelButton()
                                     .show()
                             else ->
                                 importOtherActivityResultLauncher.launch(
@@ -438,9 +440,9 @@ class SettingsFragment : Fragment() {
                         }
                     }
                     .setNeutralButton(R.string.cancel) { dialog, _ -> dialog.cancel() }
-                    .show()
+                    .showAndFocus(fullWidth = true)
             }
-            .addCancelButton()
+            .setCancelButton()
             .show()
     }
 
@@ -576,7 +578,7 @@ class SettingsFragment : Fragment() {
                 MaterialAlertDialogBuilder(requireContext())
                     .setMessage(R.string.clear_data_message)
                     .setPositiveButton(R.string.delete_all) { _, _ -> model.deleteAll() }
-                    .addCancelButton()
+                    .setCancelButton()
                     .show()
             }
         }
@@ -636,7 +638,7 @@ class SettingsFragment : Fragment() {
                                 }
                         }
                     }
-                    .addCancelButton()
+                    .setCancelButton()
                     .show()
             }
             SourceCode.setOnClickListener { openLink("https://github.com/PhilKes/NotallyX") }
@@ -677,7 +679,7 @@ class SettingsFragment : Fragment() {
                             8 -> openLink("https://github.com/zhanghai/AndroidFastScroll")
                         }
                     }
-                    .addCancelButton()
+                    .setCancelButton()
                     .show()
             }
 

--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/main/fragment/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/main/fragment/settings/SettingsFragment.kt
@@ -29,7 +29,6 @@ import com.philkes.notallyx.data.imports.txt.APPLICATION_TEXT_MIME_TYPES
 import com.philkes.notallyx.data.model.toText
 import com.philkes.notallyx.databinding.DialogTextInputBinding
 import com.philkes.notallyx.databinding.FragmentSettingsBinding
-import com.philkes.notallyx.databinding.TextInputDialogBinding
 import com.philkes.notallyx.presentation.setCancelButton
 import com.philkes.notallyx.presentation.setupImportProgressDialog
 import com.philkes.notallyx.presentation.setupProgressDialog

--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/note/EditActivity.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/note/EditActivity.kt
@@ -50,6 +50,7 @@ import com.philkes.notallyx.presentation.displayFormattedTimestamp
 import com.philkes.notallyx.presentation.extractColor
 import com.philkes.notallyx.presentation.getQuantityString
 import com.philkes.notallyx.presentation.isLightColor
+import com.philkes.notallyx.presentation.setCancelButton
 import com.philkes.notallyx.presentation.setControlsContrastColorForAllViews
 import com.philkes.notallyx.presentation.setLightStatusAndNavBar
 import com.philkes.notallyx.presentation.setupProgressDialog
@@ -529,7 +530,7 @@ abstract class EditActivity(private val type: Type) :
             if (shouldShowRequestPermissionRationale(permission)) {
                 MaterialAlertDialogBuilder(this)
                     .setMessage(R.string.please_grant_notally_audio)
-                    .setNegativeButton(R.string.cancel, null)
+                    .setCancelButton()
                     .setPositiveButton(R.string.continue_) { _, _ ->
                         requestPermissions(arrayOf(permission), REQUEST_AUDIO_PERMISSION)
                     }
@@ -548,7 +549,7 @@ abstract class EditActivity(private val type: Type) :
     private fun handleRejection() {
         MaterialAlertDialogBuilder(this)
             .setMessage(R.string.to_record_audio)
-            .setNegativeButton(R.string.cancel, null)
+            .setCancelButton()
             .setPositiveButton(R.string.settings) { _, _ ->
                 val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS)
                 intent.data = Uri.parse("package:${packageName}")
@@ -648,7 +649,7 @@ abstract class EditActivity(private val type: Type) :
                     super.finish()
                 }
             }
-            .setNegativeButton(R.string.cancel, null)
+            .setCancelButton()
             .show()
     }
 
@@ -728,7 +729,7 @@ abstract class EditActivity(private val type: Type) :
             }) { fileAttachment ->
                 MaterialAlertDialogBuilder(this)
                     .setMessage(getString(R.string.delete_file, fileAttachment.originalName))
-                    .setNegativeButton(R.string.cancel, null)
+                    .setCancelButton()
                     .setPositiveButton(R.string.delete) { _, _ ->
                         notallyModel.deleteFiles(arrayListOf(fileAttachment))
                     }
@@ -779,7 +780,7 @@ abstract class EditActivity(private val type: Type) :
         MaterialAlertDialogBuilder(this)
             .setTitle(title)
             .setView(recyclerView)
-            .setNegativeButton(R.string.cancel, null)
+            .setCancelButton()
             .setCancelable(false)
             .show()
     }

--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/note/EditNoteActivity.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/note/EditNoteActivity.kt
@@ -391,7 +391,11 @@ class EditNoteActivity : EditActivity(Type.NOTE), AddNoteActions {
                 .setItems(items) { _, which ->
                     when (which) {
                         0 -> {
-                            binding.EnterBody.removeSpanWithHistory(span, true)
+                            binding.EnterBody.removeSpanWithHistory(
+                                span,
+                                span.url.isNoteUrl() ||
+                                    span.url == binding.EnterBody.getSpanText(span),
+                            )
                         }
                         1 ->
                             if (span.url.isNoteUrl()) {

--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/note/PlayAudioActivity.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/note/PlayAudioActivity.kt
@@ -17,6 +17,7 @@ import com.philkes.notallyx.data.model.Audio
 import com.philkes.notallyx.databinding.ActivityPlayAudioBinding
 import com.philkes.notallyx.presentation.activity.LockedActivity
 import com.philkes.notallyx.presentation.add
+import com.philkes.notallyx.presentation.setCancelButton
 import com.philkes.notallyx.utils.audio.AudioPlayService
 import com.philkes.notallyx.utils.audio.LocalBinder
 import com.philkes.notallyx.utils.getExternalAudioDirectory
@@ -128,7 +129,7 @@ class PlayAudioActivity : LockedActivity<ActivityPlayAudioBinding>() {
     private fun delete() {
         MaterialAlertDialogBuilder(this)
             .setMessage(R.string.delete_audio_recording_forever)
-            .setNegativeButton(R.string.cancel, null)
+            .setCancelButton()
             .setPositiveButton(R.string.delete) { _, _ ->
                 val intent = Intent()
                 intent.putExtra(EXTRA_AUDIO, audio)

--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/note/SelectLabelsActivity.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/note/SelectLabelsActivity.kt
@@ -13,6 +13,7 @@ import com.philkes.notallyx.databinding.ActivityLabelBinding
 import com.philkes.notallyx.databinding.DialogInputBinding
 import com.philkes.notallyx.presentation.activity.LockedActivity
 import com.philkes.notallyx.presentation.add
+import com.philkes.notallyx.presentation.setCancelButton
 import com.philkes.notallyx.presentation.showAndFocus
 import com.philkes.notallyx.presentation.showToast
 import com.philkes.notallyx.presentation.view.main.label.SelectableLabelAdapter
@@ -59,7 +60,7 @@ class SelectLabelsActivity : LockedActivity<ActivityLabelBinding>() {
         MaterialAlertDialogBuilder(this)
             .setTitle(R.string.add_label)
             .setView(binding.root)
-            .setNegativeButton(R.string.cancel, null)
+            .setCancelButton()
             .setPositiveButton(R.string.save) { dialog, _ ->
                 val value = binding.EditText.text.toString().trim()
                 if (value.isNotEmpty()) {

--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/note/SelectLabelsActivity.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/note/SelectLabelsActivity.kt
@@ -72,7 +72,7 @@ class SelectLabelsActivity : LockedActivity<ActivityLabelBinding>() {
                     }
                 }
             }
-            .showAndFocus(binding.EditText)
+            .showAndFocus(binding.EditText, allowFullSize = true)
     }
 
     private fun setupRecyclerView() {

--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/note/ViewImageActivity.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/note/ViewImageActivity.kt
@@ -21,6 +21,7 @@ import com.philkes.notallyx.databinding.ActivityViewImageBinding
 import com.philkes.notallyx.presentation.activity.LockedActivity
 import com.philkes.notallyx.presentation.activity.note.EditActivity.Companion.EXTRA_SELECTED_BASE_NOTE
 import com.philkes.notallyx.presentation.add
+import com.philkes.notallyx.presentation.setCancelButton
 import com.philkes.notallyx.presentation.view.note.image.ImageAdapter
 import com.philkes.notallyx.utils.getExternalImagesDirectory
 import com.philkes.notallyx.utils.getUriForFile
@@ -218,7 +219,7 @@ class ViewImageActivity : LockedActivity<ActivityViewImageBinding>() {
     private fun delete(position: Int, adapter: ImageAdapter) {
         MaterialAlertDialogBuilder(this)
             .setMessage(R.string.delete_image_forever)
-            .setNegativeButton(R.string.cancel, null)
+            .setCancelButton()
             .setPositiveButton(R.string.delete) { _, _ ->
                 val image = adapter.items.removeAt(position)
                 deletedImages.add(image)

--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/note/reminders/RemindersActivity.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/note/reminders/RemindersActivity.kt
@@ -26,10 +26,10 @@ import com.philkes.notallyx.databinding.DialogReminderCustomRepetitionBinding
 import com.philkes.notallyx.databinding.DialogReminderRepetitionBinding
 import com.philkes.notallyx.presentation.activity.LockedActivity
 import com.philkes.notallyx.presentation.add
-import com.philkes.notallyx.presentation.addCancelButton
 import com.philkes.notallyx.presentation.checkAlarmPermission
 import com.philkes.notallyx.presentation.checkNotificationPermission
 import com.philkes.notallyx.presentation.initListView
+import com.philkes.notallyx.presentation.setCancelButton
 import com.philkes.notallyx.presentation.showAndFocus
 import com.philkes.notallyx.presentation.view.main.reminder.ReminderAdapter
 import com.philkes.notallyx.presentation.view.main.reminder.ReminderListener
@@ -279,7 +279,7 @@ class RemindersActivity : LockedActivity<ActivityRemindersBinding>(), ReminderLi
                         onRepetitionSelected,
                     )
                 }
-                .showAndFocus(dialogView.Value)
+                .showAndFocus(dialogView.Value, fullWidth = true)
         val positiveButton = dialog.getButton(AlertDialog.BUTTON_POSITIVE)
         dialogView.Value.doAfterTextChanged { text ->
             positiveButton.isEnabled = text.hasValueBiggerZero()
@@ -307,7 +307,7 @@ class RemindersActivity : LockedActivity<ActivityRemindersBinding>(), ReminderLi
             .setPositiveButton(R.string.delete) { _, _ ->
                 lifecycleScope.launch { model.removeReminder(reminder) }
             }
-            .addCancelButton()
+            .setCancelButton()
             .show()
     }
 

--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/note/reminders/RemindersActivity.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/note/reminders/RemindersActivity.kt
@@ -279,7 +279,7 @@ class RemindersActivity : LockedActivity<ActivityRemindersBinding>(), ReminderLi
                         onRepetitionSelected,
                     )
                 }
-                .showAndFocus(dialogView.Value, fullWidth = true)
+                .showAndFocus(dialogView.Value, allowFullSize = true)
         val positiveButton = dialog.getButton(AlertDialog.BUTTON_POSITIVE)
         dialogView.Value.doAfterTextChanged { text ->
             positiveButton.isEnabled = text.hasValueBiggerZero()

--- a/app/src/main/java/com/philkes/notallyx/presentation/view/misc/StylableEditTextWithHistory.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/view/misc/StylableEditTextWithHistory.kt
@@ -374,7 +374,7 @@ class StylableEditTextWithHistory(context: Context, attrs: AttributeSet) :
             .showAndFocus(
                 viewToFocus = if (isNoteUrl) layout.InputText1 else layout.InputText2,
                 selectAll = isNewUnnamedLink,
-                fullWidth = true,
+                allowFullSize = true,
             )
     }
 }

--- a/app/src/main/java/com/philkes/notallyx/presentation/view/misc/StylableEditTextWithHistory.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/view/misc/StylableEditTextWithHistory.kt
@@ -362,10 +362,14 @@ class StylableEditTextWithHistory(context: Context, attrs: AttributeSet) :
                 dialog.cancel()
                 onClose?.invoke()
             }
-            .setNeutralButton(R.string.clear) { dialog, _ ->
-                dialog.cancel()
-                onSuccess.invoke(null, displayTextBefore)
-                onClose?.invoke()
+            .apply {
+                if (!isNoteUrl) {
+                    setNeutralButton(R.string.clear) { dialog, _ ->
+                        dialog.cancel()
+                        onSuccess.invoke(null, displayTextBefore)
+                        onClose?.invoke()
+                    }
+                }
             }
             .showAndFocus(
                 viewToFocus = if (isNoteUrl) layout.InputText1 else layout.InputText2,

--- a/app/src/main/java/com/philkes/notallyx/presentation/view/misc/StylableEditTextWithHistory.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/view/misc/StylableEditTextWithHistory.kt
@@ -13,7 +13,6 @@ import android.text.style.URLSpan
 import android.util.AttributeSet
 import android.view.ActionMode
 import android.view.LayoutInflater
-import android.view.WindowManager
 import androidx.appcompat.widget.AppCompatEditText
 import androidx.core.content.ContextCompat
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
@@ -23,6 +22,7 @@ import com.philkes.notallyx.databinding.DialogTextInput2Binding
 import com.philkes.notallyx.presentation.clone
 import com.philkes.notallyx.presentation.createTextWatcherWithHistory
 import com.philkes.notallyx.presentation.removeSelectionFromSpans
+import com.philkes.notallyx.presentation.setCancelButton
 import com.philkes.notallyx.presentation.showAndFocus
 import com.philkes.notallyx.utils.changehistory.ChangeHistory
 import com.philkes.notallyx.utils.changehistory.EditTextState
@@ -349,34 +349,28 @@ class StylableEditTextWithHistory(context: Context, attrs: AttributeSet) :
                 }
             }
 
-        val dialog =
-            MaterialAlertDialogBuilder(context)
-                .setView(layout.root)
-                .setTitle(R.string.edit_link)
-                .setPositiveButton(R.string.save) { _, _ ->
-                    val displayTextAfter = layout.InputText1.text.toString()
-                    val urlAfter = layout.InputText2.text.toString()
-                    onSuccess.invoke(urlAfter, displayTextAfter)
-                    onClose?.invoke()
-                }
-                .setBackgroundInsetEnd(0)
-                .setBackgroundInsetStart(0)
-                .setNegativeButton(R.string.cancel) { dialog, _ ->
-                    dialog.cancel()
-                    onClose?.invoke()
-                }
-                .setNeutralButton(R.string.clear) { dialog, _ ->
-                    dialog.cancel()
-                    onSuccess.invoke(null, displayTextBefore)
-                    onClose?.invoke()
-                }
-                .showAndFocus(
-                    if (isNoteUrl) layout.InputText1 else layout.InputText2,
-                    isNewUnnamedLink,
-                )
-        dialog.window?.setLayout(
-            WindowManager.LayoutParams.MATCH_PARENT,
-            WindowManager.LayoutParams.WRAP_CONTENT,
-        )
+        MaterialAlertDialogBuilder(context)
+            .setView(layout.root)
+            .setTitle(R.string.edit_link)
+            .setPositiveButton(R.string.save) { _, _ ->
+                val displayTextAfter = layout.InputText1.text.toString()
+                val urlAfter = layout.InputText2.text.toString()
+                onSuccess.invoke(urlAfter, displayTextAfter)
+                onClose?.invoke()
+            }
+            .setCancelButton { dialog, _ ->
+                dialog.cancel()
+                onClose?.invoke()
+            }
+            .setNeutralButton(R.string.clear) { dialog, _ ->
+                dialog.cancel()
+                onSuccess.invoke(null, displayTextBefore)
+                onClose?.invoke()
+            }
+            .showAndFocus(
+                viewToFocus = if (isNoteUrl) layout.InputText1 else layout.InputText2,
+                selectAll = isNewUnnamedLink,
+                fullWidth = true,
+            )
     }
 }


### PR DESCRIPTION
Fixes #302  and Fixes #201 

- Decreases the background insets for all input dialogs for all sides to 0
- Allows input dialogs to use entire width

  <p>
  <img src="https://github.com/user-attachments/assets/6479b25e-114c-446f-83f4-86e7a4ba82f7" width=300 />
  <img src="https://github.com/user-attachments/assets/fa471105-ea56-43e1-b7f9-c7e86faaa9fb" width=300 />
  <p/>
  <p>
  <img src="https://github.com/user-attachments/assets/d0a69975-73d8-4236-8e27-0bfb230142a4" width=300 />
  <img src="https://github.com/user-attachments/assets/1cfa7c46-2a9b-46ba-99a1-ac2fa42a1d16" width=300 />
  </p>

For Links the Remove/Clear behaviour is as follows:
1. If the link's text and URL are the same:
   - Click Link -> "Remove Link" -> will remove the Hyperlink *and* the displayed text, since they are equal
2. If the link's text and URL are different:
   - Click Link -> "Remove Link" -> will remove the Hyperlink *but not* the displayed text
2. If the link is a note link:
   - Click Link -> "Remove Link" -> will remove the Hyperlink *and* the displayed text

For any of these scenarios the hyperlink can be removed without removing the displayed text via:
Click Link -> "Edit" (Or click hyperlink symbol in bottom bar if link text is selected) -> "Clear" 

