### PR TITLE
Save open note on crash

### DIFF
--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/note/EditListActivity.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/note/EditListActivity.kt
@@ -39,11 +39,12 @@ class EditListActivity : EditActivity(Type.LIST), MoreListActions {
     private lateinit var listManager: ListManager
 
     override fun finish() {
-        updateModel()
+        notallyModel.setItems(items.toMutableList() + (itemsChecked?.toMutableList() ?: listOf()))
         super.finish()
     }
 
-    private fun updateModel() {
+    override fun updateModel() {
+        super.updateModel()
         notallyModel.setItems(items.toMutableList() + (itemsChecked?.toMutableList() ?: listOf()))
     }
 

--- a/app/src/main/java/com/philkes/notallyx/utils/AndroidExtensions.kt
+++ b/app/src/main/java/com/philkes/notallyx/utils/AndroidExtensions.kt
@@ -183,8 +183,10 @@ fun Context.logToFile(
     stackTrace: String? = null,
 ) {
     msg?.let {
-        if (throwable != null || stackTrace != null) {
-            Log.e(tag, it)
+        if (throwable != null) {
+            Log.e(tag, it, throwable)
+        } else if (stackTrace != null) {
+            Log.e(tag, "$it: $stackTrace")
         } else {
             Log.i(tag, it)
         }
@@ -249,7 +251,7 @@ fun Context.catchNoBrowserInstalled(callback: () -> Unit) {
     try {
         callback()
     } catch (exception: ActivityNotFoundException) {
-        showToast(com.philkes.notallyx.R.string.install_a_browser)
+        showToast(R.string.install_a_browser)
     }
 }
 
@@ -258,10 +260,19 @@ fun Context.createReportBugIntent(
     title: String? = null,
     body: String? = null,
 ): Intent {
+    fun String?.asQueryParam(paramName: String): String {
+        return this?.let { "&$paramName=${URLEncoder.encode(this, "UTF-8")}" } ?: ""
+    }
     return Intent(
             Intent.ACTION_VIEW,
             Uri.parse(
-                "https://github.com/PhilKes/NotallyX/issues/new?labels=bug&projects=&template=bug_report.yml${title?.let { "&title=$it" } ?: ""}${body?.let { "&what-happened=$it" } ?: ""}&version=${BuildConfig.VERSION_NAME}&android-version=${Build.VERSION.SDK_INT}${stackTrace?.let { "&logs=$stackTrace" } ?: ""}"
+                "https://github.com/PhilKes/NotallyX/issues/new?labels=bug&projects=&template=bug_report.yml${
+                    title.asQueryParam("title")
+                }&version=${BuildConfig.VERSION_NAME}&android-version=${Build.VERSION.SDK_INT}${
+                    stackTrace.asQueryParam("logs")
+                }${
+                    body.asQueryParam("what-happened")
+                    }"
                     .take(2000)
             ),
         )

--- a/app/src/main/java/com/philkes/notallyx/utils/ErrorActivity.kt
+++ b/app/src/main/java/com/philkes/notallyx/utils/ErrorActivity.kt
@@ -24,10 +24,11 @@ class ErrorActivity : AppCompatActivity() {
             }
 
             val stackTrace = CustomActivityOnCrash.getStackTraceFromIntent(intent)
-            stackTrace?.let { application.log(TAG, stackTrace = it) }
-            ReportButton.setOnClickListener {
-                reportBug(CustomActivityOnCrash.getStackTraceFromIntent(intent))
+            stackTrace?.let {
+                application.log(TAG, stackTrace = it)
+                Exception.text = stackTrace.lines().firstOrNull() ?: ""
             }
+            ReportButton.setOnClickListener { reportBug(stackTrace) }
         }
     }
 

--- a/app/src/main/res/layout/activity_error.xml
+++ b/app/src/main/res/layout/activity_error.xml
@@ -38,6 +38,14 @@
         android:textSize="18sp"
         android:textStyle="bold" />
 
+      <TextView
+        android:id="@+id/Exception"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/customactivityoncrash_activity_vertical_margin"
+        android:gravity="center"
+        android:textSize="14sp" />
+
       <Button
         android:id="@+id/RestartButton"
         android:layout_width="wrap_content"


### PR DESCRIPTION
Improves crash behaviour for #402 

- When the app crashes when editing/viewing a note, the note is saved before the `ErrorActivity` is shown
- Added first line of Exception stacktrace to `ErrorActivity` view