### PR TITLE
Hide hidden labels in overview and quick jump to label from note view

### DIFF
--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/main/MainActivity.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/main/MainActivity.kt
@@ -95,7 +95,7 @@ class MainActivity : LockedActivity<ActivityMainBinding>() {
 
         val fragmentIdToLoad = intent.getIntExtra(EXTRA_FRAGMENT_TO_OPEN, -1)
         if (fragmentIdToLoad != -1) {
-            navController.navigate(fragmentIdToLoad, Bundle())
+            navController.navigate(fragmentIdToLoad, intent.extras)
         } else if (savedInstanceState == null) {
             navigateToStartView()
         }
@@ -107,7 +107,10 @@ class MainActivity : LockedActivity<ActivityMainBinding>() {
                     if (baseModel.actionMode.enabled.value) {
                         return
                     }
-                    if (!isStartViewFragment) {
+                    if (
+                        !isStartViewFragment &&
+                            !intent.getBooleanExtra(EXTRA_SKIP_START_VIEW_ON_BACK, false)
+                    ) {
                         navigateToStartView()
                     } else {
                         finish()
@@ -689,5 +692,6 @@ class MainActivity : LockedActivity<ActivityMainBinding>() {
 
     companion object {
         const val EXTRA_FRAGMENT_TO_OPEN = "notallyx.intent.extra.FRAGMENT_TO_OPEN"
+        const val EXTRA_SKIP_START_VIEW_ON_BACK = "notallyx.intent.extra.SKIP_START_VIEW_ON_BACK"
     }
 }

--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/main/fragment/LabelsFragment.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/main/fragment/LabelsFragment.kt
@@ -6,7 +6,6 @@ import android.view.Menu
 import android.view.MenuInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.Toast
 import androidx.core.view.isVisible
 import androidx.core.widget.doAfterTextChanged
 import androidx.fragment.app.Fragment
@@ -19,6 +18,7 @@ import com.philkes.notallyx.databinding.DialogInputBinding
 import com.philkes.notallyx.databinding.FragmentNotesBinding
 import com.philkes.notallyx.presentation.activity.main.fragment.DisplayLabelFragment.Companion.EXTRA_DISPLAYED_LABEL
 import com.philkes.notallyx.presentation.add
+import com.philkes.notallyx.presentation.displayEditLabelDialog
 import com.philkes.notallyx.presentation.initListView
 import com.philkes.notallyx.presentation.setCancelButton
 import com.philkes.notallyx.presentation.showAndFocus
@@ -77,7 +77,7 @@ class LabelsFragment : Fragment(), LabelListener {
 
     override fun onEdit(position: Int) {
         labelAdapter?.currentList?.get(position)?.let { (label, _) ->
-            displayEditLabelDialog(label)
+            displayEditLabelDialog(label, model)
         }
     }
 
@@ -147,38 +147,5 @@ class LabelsFragment : Fragment(), LabelListener {
             .setPositiveButton(R.string.delete) { _, _ -> model.deleteLabel(value) }
             .setCancelButton()
             .show()
-    }
-
-    private fun displayEditLabelDialog(oldValue: String) {
-        val dialogBinding = DialogInputBinding.inflate(layoutInflater)
-
-        dialogBinding.EditText.setText(oldValue)
-
-        MaterialAlertDialogBuilder(requireContext())
-            .setView(dialogBinding.root)
-            .setTitle(R.string.edit_label)
-            .setCancelButton()
-            .setPositiveButton(R.string.save) { dialog, _ ->
-                val value = dialogBinding.EditText.text.toString().trim()
-                if (value.isNotEmpty()) {
-                    model.updateLabel(oldValue, value) { success ->
-                        if (success) {
-                            dialog.dismiss()
-                        } else
-                            Toast.makeText(
-                                    requireContext(),
-                                    R.string.label_exists,
-                                    Toast.LENGTH_LONG,
-                                )
-                                .show()
-                    }
-                }
-            }
-            .showAndFocus(dialogBinding.EditText, allowFullSize = true) { positiveButton ->
-                dialogBinding.EditText.doAfterTextChanged { text ->
-                    positiveButton.isEnabled = !text.isNullOrEmpty()
-                }
-                positiveButton.isEnabled = oldValue.isNotEmpty()
-            }
     }
 }

--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/note/EditActivity.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/note/EditActivity.kt
@@ -43,6 +43,9 @@ import com.philkes.notallyx.data.model.Type
 import com.philkes.notallyx.data.model.toText
 import com.philkes.notallyx.databinding.ActivityEditBinding
 import com.philkes.notallyx.presentation.activity.LockedActivity
+import com.philkes.notallyx.presentation.activity.main.MainActivity
+import com.philkes.notallyx.presentation.activity.main.MainActivity.Companion.EXTRA_FRAGMENT_TO_OPEN
+import com.philkes.notallyx.presentation.activity.main.MainActivity.Companion.EXTRA_SKIP_START_VIEW_ON_BACK
 import com.philkes.notallyx.presentation.activity.main.fragment.DisplayLabelFragment.Companion.EXTRA_DISPLAYED_LABEL
 import com.philkes.notallyx.presentation.activity.note.SelectLabelsActivity.Companion.EXTRA_SELECTED_LABELS
 import com.philkes.notallyx.presentation.activity.note.reminders.RemindersActivity
@@ -50,6 +53,7 @@ import com.philkes.notallyx.presentation.add
 import com.philkes.notallyx.presentation.addFastScroll
 import com.philkes.notallyx.presentation.addIconButton
 import com.philkes.notallyx.presentation.bindLabels
+import com.philkes.notallyx.presentation.displayEditLabelDialog
 import com.philkes.notallyx.presentation.displayFormattedTimestamp
 import com.philkes.notallyx.presentation.extractColor
 import com.philkes.notallyx.presentation.getQuantityString
@@ -629,13 +633,37 @@ abstract class EditActivity(private val type: Type) :
             } else DateFormat.ABSOLUTE
         binding.Date.displayFormattedTimestamp(date, dateFormat, datePrefixResId)
         binding.EnterTitle.setText(notallyModel.title)
+        bindLabels()
+        setColor()
+    }
+
+    private fun bindLabels() {
         binding.LabelGroup.bindLabels(
             notallyModel.labels,
             notallyModel.textSize,
             paddingTop = true,
             colorInt,
+            onClick = { label ->
+                val bundle = Bundle()
+                bundle.putString(EXTRA_DISPLAYED_LABEL, label)
+                startActivity(
+                    Intent(this, MainActivity::class.java).apply {
+                        putExtra(EXTRA_FRAGMENT_TO_OPEN, R.id.DisplayLabel)
+                        putExtra(EXTRA_DISPLAYED_LABEL, label)
+                        putExtra(EXTRA_SKIP_START_VIEW_ON_BACK, true)
+                    }
+                )
+            },
+            onLongClick = { label ->
+                displayEditLabelDialog(label, baseModel) { oldLabel, newLabel ->
+                    notallyModel.labels.apply {
+                        remove(oldLabel)
+                        add(newLabel)
+                    }
+                    bindLabels()
+                }
+            },
         )
-        setColor()
     }
 
     private fun handleSharedNote() {


### PR DESCRIPTION
Closes #180 

- When clicking a label inside a note you can view all notes with that label
- When long clicking a label inside a note you can edit that label

[notallyx_issues_180.webm](https://github.com/user-attachments/assets/711ddd80-85bb-404c-aa24-04770a31c348)
