### PR TITLE
Do not show hidden labels in notes overview

### DIFF
--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/main/MainActivity.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/main/MainActivity.kt
@@ -195,7 +195,7 @@ class MainActivity : LockedActivity<ActivityMainBinding>() {
                 .setCheckable(true)
                 .setIcon(R.drawable.settings)
         }
-        baseModel.preferences.labelsHiddenInNavigation.observe(this) { hiddenLabels ->
+        baseModel.preferences.labelsHidden.observe(this) { hiddenLabels ->
             hideLabelsInNavigation(hiddenLabels, baseModel.preferences.maxLabels.value)
         }
         baseModel.preferences.maxLabels.observe(this) { maxLabels ->
@@ -244,10 +244,7 @@ class MainActivity : LockedActivity<ActivityMainBinding>() {
             } else null
         configuration = AppBarConfiguration(binding.NavigationView.menu, binding.DrawerLayout)
         setupActionBarWithNavController(navController, configuration)
-        hideLabelsInNavigation(
-            baseModel.preferences.labelsHiddenInNavigation.value,
-            maxLabelsToDisplay,
-        )
+        hideLabelsInNavigation(baseModel.preferences.labelsHidden.value, maxLabelsToDisplay)
     }
 
     private fun navigateToLabel(label: String) {

--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/main/fragment/LabelsFragment.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/main/fragment/LabelsFragment.kt
@@ -87,13 +87,13 @@ class LabelsFragment : Fragment(), LabelListener {
 
     override fun onToggleVisibility(position: Int) {
         labelAdapter?.currentList?.get(position)?.let { value ->
-            val hiddenLabels = model.preferences.labelsHiddenInNavigation.value.toMutableSet()
+            val hiddenLabels = model.preferences.labelsHidden.value.toMutableSet()
             if (value.visibleInNavigation) {
                 hiddenLabels.add(value.label)
             } else {
                 hiddenLabels.remove(value.label)
             }
-            model.savePreference(model.preferences.labelsHiddenInNavigation, hiddenLabels)
+            model.savePreference(model.preferences.labelsHidden, hiddenLabels)
 
             val currentList = labelAdapter!!.currentList.toMutableList()
             currentList[position] =
@@ -104,7 +104,7 @@ class LabelsFragment : Fragment(), LabelListener {
 
     private fun setupObserver() {
         model.labels.observe(viewLifecycleOwner) { labels ->
-            val hiddenLabels = model.preferences.labelsHiddenInNavigation.value
+            val hiddenLabels = model.preferences.labelsHidden.value
             val labelsData = labels.map { label -> LabelData(label, !hiddenLabels.contains(label)) }
             labelAdapter?.submitList(labelsData)
             binding?.ImageView?.isVisible = labels.isEmpty()

--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/main/fragment/NotallyFragment.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/main/fragment/NotallyFragment.kt
@@ -243,7 +243,7 @@ abstract class NotallyFragment : Fragment(), ItemListener {
                         maxItems.value,
                         maxLines.value,
                         maxTitle.value,
-                        labelsHiddenInOverview.value,
+                        labelTagsHiddenInOverview.value,
                     ),
                     model.imageRoot,
                     this@NotallyFragment,

--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/main/fragment/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/main/fragment/settings/SettingsFragment.kt
@@ -339,15 +339,15 @@ class SettingsFragment : Fragment() {
             MaxLabels.setup(maxLabels, requireContext()) { newValue ->
                 model.savePreference(maxLabels, newValue)
             }
-            labelsHiddenInOverview.observe(viewLifecycleOwner) { value ->
+            labelTagsHiddenInOverview.observe(viewLifecycleOwner) { value ->
                 binding.LabelsHiddenInOverview.setup(
-                    labelsHiddenInOverview,
+                    labelTagsHiddenInOverview,
                     value,
                     requireContext(),
                     layoutInflater,
                     R.string.labels_hidden_in_overview,
                 ) { enabled ->
-                    model.savePreference(labelsHiddenInOverview, enabled)
+                    model.savePreference(labelTagsHiddenInOverview, enabled)
                 }
             }
         }

--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/note/PickNoteActivity.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/note/PickNoteActivity.kt
@@ -51,7 +51,7 @@ open class PickNoteActivity : LockedActivity<ActivityPickNoteBinding>(), ItemLis
                         maxItems.value,
                         maxLines.value,
                         maxTitle.value,
-                        labelsHiddenInOverview.value,
+                        labelTagsHiddenInOverview.value,
                     ),
                     application.getExternalImagesDirectory(),
                     this@PickNoteActivity,

--- a/app/src/main/java/com/philkes/notallyx/presentation/viewmodel/preference/NotallyXPreferences.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/viewmodel/preference/NotallyXPreferences.kt
@@ -76,9 +76,8 @@ class NotallyXPreferences private constructor(private val context: Context) {
             10,
             R.string.max_lines_to_display_title,
         )
-    val labelsHiddenInNavigation =
-        StringSetPreference("labelsHiddenInNavigation", preferences, setOf())
-    val labelsHiddenInOverview =
+    val labelsHidden = StringSetPreference("labelsHiddenInNavigation", preferences, setOf())
+    val labelTagsHiddenInOverview =
         BooleanPreference(
             "labelsHiddenInOverview",
             preferences,
@@ -224,8 +223,8 @@ class NotallyXPreferences private constructor(private val context: Context) {
                 maxItems,
                 maxLines,
                 maxTitle,
-                labelsHiddenInNavigation,
-                labelsHiddenInOverview,
+                labelsHidden,
+                labelTagsHiddenInOverview,
                 maxLabels,
                 periodicBackups,
                 backupPassword,

--- a/app/src/main/res/layout-v26/recycler_label.xml
+++ b/app/src/main/res/layout-v26/recycler_label.xml
@@ -22,8 +22,8 @@
     android:layout_gravity="center_vertical"
     android:padding="8dp"
     android:background="?attr/selectableItemBackground"
-    android:contentDescription="@string/label_visibility"
-    android:tooltipText="@string/label_visibility"
+    android:contentDescription="@string/labels_hidden_in_overview_title"
+    android:tooltipText="@string/labels_hidden_in_overview_title"
     app:srcCompat="@drawable/visibility"
     app:tint="?attr/colorControlNormal" />
 

--- a/app/src/main/res/layout/recycler_label.xml
+++ b/app/src/main/res/layout/recycler_label.xml
@@ -23,7 +23,7 @@
     android:layout_gravity="center_vertical"
     android:padding="8dp"
     android:background="?attr/selectableItemBackground"
-    android:contentDescription="@string/label_visibility"
+    android:contentDescription="@string/labels_hidden_in_overview_title"
     app:srcCompat="@drawable/visibility"
     app:tint="?attr/colorControlNormal" />
 


### PR DESCRIPTION
Closes #401 

- When a label is hidden in the "Labels" View, the notes with that label are also hidden in the notes overview