### PR TITLE
Add attached images to share note and support sharing files to the app

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -68,7 +68,13 @@
             <intent-filter>
                 <action android:name="android.intent.action.SEND" />
                 <category android:name="android.intent.category.DEFAULT" />
-                <data android:mimeType="text/plain" />
+                <data android:mimeType="*/*" />
+            </intent-filter>
+
+            <intent-filter>
+                <action android:name="android.intent.action.SEND_MULTIPLE" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="*/*" />
             </intent-filter>
 
         </activity>

--- a/app/src/main/java/com/philkes/notallyx/data/model/ModelExtensions.kt
+++ b/app/src/main/java/com/philkes/notallyx/data/model/ModelExtensions.kt
@@ -43,7 +43,15 @@ fun String.getNoteTypeFromUrl(): Type {
 
 val FileAttachment.isImage: Boolean
     get() {
-        return mimeType.startsWith("image/")
+        return mimeType.isImageMimeType
+    }
+val String.isImageMimeType: Boolean
+    get() {
+        return startsWith("image/")
+    }
+val String.isAudioMimeType: Boolean
+    get() {
+        return startsWith("audio/")
     }
 
 fun BaseNote.toTxt(includeTitle: Boolean = true, includeCreationDate: Boolean = true) =

--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/main/MainActivity.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/main/MainActivity.kt
@@ -321,12 +321,7 @@ class MainActivity : LockedActivity<ActivityMainBinding>() {
 
     private fun share() {
         val baseNote = baseModel.actionMode.getFirstNote()
-        val body =
-            when (baseNote.type) {
-                Type.NOTE -> baseNote.body.applySpans(baseNote.spans)
-                Type.LIST -> baseNote.items.toText()
-            }
-        this.shareNote(baseNote.title, body)
+        this.shareNote(baseNote)
     }
 
     private fun deleteForever() {

--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/note/EditActivity.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/note/EditActivity.kt
@@ -793,12 +793,7 @@ abstract class EditActivity(private val type: Type) :
     }
 
     override fun share() {
-        val body =
-            when (type) {
-                Type.NOTE -> notallyModel.body
-                Type.LIST -> notallyModel.items.toMutableList().toText()
-            }
-        this.shareNote(notallyModel.title, body)
+        this.shareNote(notallyModel.getBaseNote())
     }
 
     override fun export(mimeType: ExportMimeType) {

--- a/app/src/main/java/com/philkes/notallyx/utils/AndroidExtensions.kt
+++ b/app/src/main/java/com/philkes/notallyx/utils/AndroidExtensions.kt
@@ -34,6 +34,7 @@ import com.philkes.notallyx.BuildConfig
 import com.philkes.notallyx.R
 import com.philkes.notallyx.data.model.BaseNote
 import com.philkes.notallyx.data.model.Type
+import com.philkes.notallyx.data.model.toText
 import com.philkes.notallyx.presentation.activity.note.EditActivity.Companion.EXTRA_SELECTED_BASE_NOTE
 import com.philkes.notallyx.presentation.activity.note.EditListActivity
 import com.philkes.notallyx.presentation.activity.note.EditNoteActivity
@@ -152,6 +153,8 @@ fun Context.getUriForFile(file: File): Uri =
     FileProvider.getUriForFile(this, "${packageName}.provider", file)
 
 private val LOG_DATE_FORMATTER = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.ENGLISH)
+
+fun Context.getMimeType(uri: Uri) = contentResolver.getType(uri)
 
 fun ContextWrapper.log(
     tag: String,
@@ -297,22 +300,23 @@ fun ContextWrapper.shareNote(note: BaseNote) {
             Type.NOTE -> note.body
             Type.LIST -> note.items.toMutableList().toText()
         }
-    val filesUris = note.images
-        .map {File(getExternalImagesDirectory(), it.localName)}
-        .map { getUriForFile(it) }
+    val filesUris =
+        note.images
+            .map { File(getExternalImagesDirectory(), it.localName) }
+            .map { getUriForFile(it) }
     shareNote(note.title, body, filesUris)
 }
 
 private fun Context.shareNote(title: String, body: CharSequence, imageUris: List<Uri>) {
     val text = body.truncate(150_000)
     val intent =
-        Intent(if(imageUris.size >1) Intent.ACTION_SEND_MULTIPLE else Intent.ACTION_SEND)
+        Intent(if (imageUris.size > 1) Intent.ACTION_SEND_MULTIPLE else Intent.ACTION_SEND)
             .apply {
                 type = "image/*"
                 putExtra(Intent.EXTRA_TEXT, text.toString())
                 putExtra(Intent.EXTRA_TITLE, title)
                 putExtra(Intent.EXTRA_SUBJECT, title)
-                if(imageUris.size >1){
+                if (imageUris.size > 1) {
                     putParcelableArrayListExtra(Intent.EXTRA_STREAM, ArrayList(imageUris))
                 } else {
                     putExtra(Intent.EXTRA_STREAM, imageUris.firstOrNull())


### PR DESCRIPTION
Closes #380 
Closes #281 

- Add attached images to share note: 

  [notallyx_issues_380.webm](https://github.com/user-attachments/assets/adfaa890-b5e6-4d61-8c97-692206e465a0)


- Support sharing images/files to the app: 

  [notallyx_issues_281.webm](https://github.com/user-attachments/assets/3a704f97-a250-4f26-ab23-6819898960c2)
