### PR TITLE
Show keyboard when EditText is focused for API < 27

### DIFF
--- a/app/src/main/java/com/philkes/notallyx/presentation/view/misc/EditTextWithWatcher.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/view/misc/EditTextWithWatcher.kt
@@ -1,6 +1,7 @@
 package com.philkes.notallyx.presentation.view.misc
 
 import android.content.Context
+import android.os.Build
 import android.text.Editable
 import android.text.TextWatcher
 import android.text.method.KeyListener
@@ -8,6 +9,7 @@ import android.util.AttributeSet
 import android.view.inputmethod.InputMethodManager
 import androidx.appcompat.widget.AppCompatEditText
 import com.philkes.notallyx.presentation.clone
+import com.philkes.notallyx.presentation.showKeyboard
 
 open class EditTextWithWatcher(context: Context, attrs: AttributeSet) :
     AppCompatEditText(context, attrs) {
@@ -42,6 +44,19 @@ open class EditTextWithWatcher(context: Context, attrs: AttributeSet) :
         isFocusable = value
         isFocusableInTouchMode = value
         setTextIsSelectable(true)
+
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O_MR1) {
+            setOnClickListener {
+                if (value) {
+                    context.showKeyboard(this)
+                }
+            }
+            setOnFocusChangeListener { v, hasFocus ->
+                if (hasFocus && value) {
+                    context.showKeyboard(this)
+                }
+            }
+        }
     }
 
     @Deprecated(


### PR DESCRIPTION
Fixes #537 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved editing experience on older Android devices by ensuring the keyboard appears automatically when editing is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->