### PR TITLE
Fix decrypting database on auto-save backup if biometric lock is enabled

### DIFF
--- a/app/src/main/java/com/philkes/notallyx/utils/backup/ExportExtensions.kt
+++ b/app/src/main/java/com/philkes/notallyx/utils/backup/ExportExtensions.kt
@@ -174,7 +174,7 @@ fun ContextWrapper.autoBackupOnSave(backupPath: String, password: String, savedN
             backupFile = folder.createFile(MIME_TYPE_ZIP, ON_SAVE_BACKUP_FILE)
             exportAsZip(backupFile!!.uri, password = password)
         } else {
-            NotallyDatabase.getDatabase(this, observePreferences = false).value.checkpoint()
+            val (_, file) = copyDatabase()
             val files =
                 with(savedNote) {
                     images.map {
@@ -192,10 +192,7 @@ fun ContextWrapper.autoBackupOnSave(backupPath: String, password: String, savedN
                         audios.map {
                             BackupFile(SUBFOLDER_AUDIOS, File(getExternalAudioDirectory(), it.name))
                         } +
-                        BackupFile(
-                            null,
-                            NotallyDatabase.getCurrentDatabaseFile(this@autoBackupOnSave),
-                        )
+                        BackupFile(null, file)
                 }
             try {
                 exportToZip(backupFile.uri, files, password)
@@ -417,7 +414,7 @@ fun ContextWrapper.copyDatabase(): Pair<NotallyDatabase, File> {
         val cipher = getInitializedCipherForDecryption(iv = preferences.iv.value!!)
         val passphrase = cipher.doFinal(preferences.databaseEncryptionKey.value)
         val decryptedFile = File(cacheDir, DATABASE_NAME)
-        decryptDatabase(this, passphrase, decryptedFile, databaseFile)
+        decryptDatabase(this, passphrase, databaseFile, decryptedFile)
         Pair(database, decryptedFile)
     } else {
         val dbFile = File(cacheDir, DATABASE_NAME)

--- a/app/src/main/java/com/philkes/notallyx/utils/backup/ExportExtensions.kt
+++ b/app/src/main/java/com/philkes/notallyx/utils/backup/ExportExtensions.kt
@@ -89,7 +89,7 @@ import net.lingala.zip4j.model.enums.EncryptionMethod
 private const val TAG = "ExportExtensions"
 private const val NOTIFICATION_CHANNEL_ID = "AutoBackups"
 private const val NOTIFICATION_ID = 123412
-private const val NOTALLYX_BACKUP_LOGS_FILE = "notallyx-backup-logs"
+private const val NOTALLYX_BACKUP_LOGS_FILE = "notallyx-backup-logs.txt"
 private const val OUTPUT_DATA_BACKUP_URI = "backupUri"
 
 const val AUTO_BACKUP_WORK_NAME = "com.philkes.notallyx.AutoBackupWork"

--- a/app/src/main/java/com/philkes/notallyx/utils/security/EncryptionUtils.kt
+++ b/app/src/main/java/com/philkes/notallyx/utils/security/EncryptionUtils.kt
@@ -37,8 +37,8 @@ fun decryptDatabase(context: ContextWrapper, passphrase: ByteArray) {
 fun decryptDatabase(
     context: Context,
     passphrase: ByteArray,
-    decryptedFile: File,
     databaseFile: File,
+    decryptedFile: File,
 ) {
     val state = SQLCipherUtils.getDatabaseState(databaseFile)
     if (state == SQLCipherUtils.State.ENCRYPTED) {


### PR DESCRIPTION
Fixes #581 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved backup reliability by ensuring backups are created from a properly copied and decrypted database file.
  - Enhanced import functionality to automatically detect and decrypt encrypted database files during restoration, providing clearer error messages if decryption keys are missing.

- **Refactor**
  - Adjusted internal parameter order for database decryption to ensure correct file handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->