### PR TITLE
Fix unwanted ListItem added on orientation change

### DIFF
--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/note/EditListActivity.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/note/EditListActivity.kt
@@ -217,7 +217,7 @@ class EditListActivity : EditActivity(Type.LIST), MoreListActions {
     override fun configureUI() {
         binding.EnterTitle.setOnNextAction { listManager.moveFocusToNext(-1) }
 
-        if (notallyModel.isNewNote || notallyModel.items.isEmpty()) {
+        if (notallyModel.items.isEmpty()) {
             listManager.add(pushChange = false)
         }
     }


### PR DESCRIPTION
Fixes #659 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted list initialization to add a blank item only when the list is empty, preventing duplicate or unnecessary items.
  * Improves consistency when creating or opening lists that already have content, avoiding unexpected extra entries and reducing accidental edits.
  * Users starting a new list will still see a blank item if none exist; existing lists remain unchanged, resulting in a cleaner editing experience and fewer manual deletions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->