### PR TITLE
Add quick action to re-choose backup folder if not exists

### DIFF
--- a/app/src/main/java/com/philkes/notallyx/utils/backup/BackupFolderNotExistsException.kt
+++ b/app/src/main/java/com/philkes/notallyx/utils/backup/BackupFolderNotExistsException.kt
@@ -1,0 +1,4 @@
+package com.philkes.notallyx.utils.backup
+
+class BackupFolderNotExistsException(val path: String, cause: Throwable? = null) :
+    IllegalArgumentException("Folder '$path' does not exist", cause)


### PR DESCRIPTION
Improves error behaviour for #645 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Error notifications for missing backup folders now include a “Select Folder” action that takes you directly to Settings to choose the backups folder, streamlining recovery.
  * Clearer messaging when the backup folder path is invalid.

* **Chores**
  * Standardized error handling for missing backup folders to ensure consistent user-facing notifications and actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->