### PR TITLE
Dont lock widget if biometric lock is not enabled

### DIFF
--- a/app/src/main/java/com/philkes/notallyx/NotallyXApplication.kt
+++ b/app/src/main/java/com/philkes/notallyx/NotallyXApplication.kt
@@ -73,7 +73,10 @@ class NotallyXApplication : Application(), Application.ActivityLifecycleCallback
                     )
             }
             if (oldTheme != null) {
-                WidgetProvider.updateWidgets(this, locked = locked.value)
+                WidgetProvider.updateWidgets(
+                    this,
+                    locked = preferences.isLockEnabled && locked.value,
+                )
             }
         }
 
@@ -109,7 +112,9 @@ class NotallyXApplication : Application(), Application.ActivityLifecycleCallback
         }
         preferences.biometricLock.observeForever(biometricLockObserver)
 
-        locked.observeForever { isLocked -> WidgetProvider.updateWidgets(this, locked = isLocked) }
+        locked.observeForever { isLocked ->
+            WidgetProvider.updateWidgets(this, locked = preferences.isLockEnabled && isLocked)
+        }
 
         preferences.backupPassword.observeForeverWithPrevious {
             (previousBackupPassword, backupPassword) ->


### PR DESCRIPTION
Fixes #614 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed widget behavior to correctly respect lock preference settings. Widgets now properly handle lock state updates only when the lock feature is enabled in preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->