### PR TITLE
Highlight keyword in notes search and jump to keyword in note

### DIFF
--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/note/EditActivity.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/note/EditActivity.kt
@@ -236,6 +236,21 @@ abstract class EditActivity(private val type: Type) :
         }
     }
 
+    override fun onStart() {
+        super.onStart()
+        // If launched with an initial search query (from global search), auto-start in-note search
+        intent.getStringExtra(EXTRA_INITIAL_SEARCH_QUERY)?.let { initialQuery ->
+            if (initialQuery.isNotBlank()) {
+                binding.EnterSearchKeyword.postOnAnimation {
+                    startSearch()
+                    binding.EnterSearchKeyword.setText(initialQuery)
+                    binding.EnterSearchKeyword.setSelection(initialQuery.length)
+                }
+            }
+            intent.removeExtra(EXTRA_INITIAL_SEARCH_QUERY)
+        }
+    }
+
     private fun configureEdgeToEdgeInsets() {
         WindowCompat.setDecorFitsSystemWindows(window, false)
 
@@ -1242,6 +1257,7 @@ abstract class EditActivity(private val type: Type) :
         const val EXTRA_NOTE_ID = "notallyx.intent.extra.NOTE_ID"
         const val EXTRA_FOLDER_FROM = "notallyx.intent.extra.FOLDER_FROM"
         const val EXTRA_FOLDER_TO = "notallyx.intent.extra.FOLDER_TO"
+        const val EXTRA_INITIAL_SEARCH_QUERY = "notallyx.intent.extra.INITIAL_SEARCH_QUERY"
 
         val DEFAULT_EXCEPTION_HANDLER = Thread.getDefaultUncaughtExceptionHandler()
     }

--- a/app/src/main/java/com/philkes/notallyx/presentation/view/main/BaseNoteAdapter.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/view/main/BaseNoteAdapter.kt
@@ -29,6 +29,8 @@ class BaseNoteAdapter(
     private val listener: ItemListener,
 ) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
 
+    private var searchKeyword: String = ""
+
     private var list = SortedList(Item::class.java, notesSort.createCallback())
 
     override fun getItemViewType(position: Int): Int {
@@ -45,13 +47,19 @@ class BaseNoteAdapter(
     override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
         when (val item = list[position]) {
             is Header -> (holder as HeaderVH).bind(item)
-            is BaseNote ->
-                (holder as BaseNoteVH).bind(
-                    item,
-                    imageRoot,
-                    selectedIds.contains(item.id),
-                    notesSort.sortedBy,
-                )
+            is BaseNote -> {
+                (holder as BaseNoteVH).apply {
+                    setSearchKeyword(searchKeyword)
+                    bind(item, imageRoot, selectedIds.contains(item.id), notesSort.sortedBy)
+                }
+            }
+        }
+    }
+
+    fun setSearchKeyword(keyword: String) {
+        if (searchKeyword != keyword) {
+            searchKeyword = keyword
+            notifyDataSetChanged()
         }
     }
 

--- a/app/src/main/java/com/philkes/notallyx/presentation/view/misc/EditTextAutoClearFocus.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/view/misc/EditTextAutoClearFocus.kt
@@ -3,6 +3,7 @@ package com.philkes.notallyx.presentation.view.misc
 import android.content.Context
 import android.util.AttributeSet
 import android.view.KeyEvent
+import com.philkes.notallyx.presentation.view.misc.highlightableview.HighlightableEditText
 
 class EditTextAutoClearFocus(context: Context, attributeSet: AttributeSet) :
     HighlightableEditText(context, attributeSet) {

--- a/app/src/main/java/com/philkes/notallyx/presentation/view/misc/StylableEditTextWithHistory.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/view/misc/StylableEditTextWithHistory.kt
@@ -24,6 +24,7 @@ import com.philkes.notallyx.presentation.createTextWatcherWithHistory
 import com.philkes.notallyx.presentation.removeSelectionFromSpans
 import com.philkes.notallyx.presentation.setCancelButton
 import com.philkes.notallyx.presentation.showAndFocus
+import com.philkes.notallyx.presentation.view.misc.highlightableview.HighlightableEditText
 import com.philkes.notallyx.utils.changehistory.ChangeHistory
 import com.philkes.notallyx.utils.changehistory.EditTextState
 import com.philkes.notallyx.utils.changehistory.EditTextWithHistoryChange

--- a/app/src/main/java/com/philkes/notallyx/presentation/view/misc/highlightableview/HighlightSpan.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/view/misc/highlightableview/HighlightSpan.kt
@@ -1,0 +1,6 @@
+package com.philkes.notallyx.presentation.view.misc.highlightableview
+
+import android.text.style.BackgroundColorSpan
+import androidx.annotation.ColorInt
+
+class HighlightSpan(@ColorInt color: Int) : BackgroundColorSpan(color)

--- a/app/src/main/java/com/philkes/notallyx/presentation/view/misc/highlightableview/HighlightableEditText.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/view/misc/highlightableview/HighlightableEditText.kt
@@ -1,13 +1,12 @@
-package com.philkes.notallyx.presentation.view.misc
+package com.philkes.notallyx.presentation.view.misc.highlightableview
 
 import android.content.Context
 import android.text.Spanned
-import android.text.style.BackgroundColorSpan
 import android.text.style.CharacterStyle
 import android.util.AttributeSet
-import androidx.annotation.ColorInt
 import androidx.appcompat.widget.AppCompatEditText
 import com.philkes.notallyx.presentation.removeSelectionFromSpans
+import com.philkes.notallyx.presentation.view.misc.EditTextWithWatcher
 import com.philkes.notallyx.presentation.withAlpha
 
 /**
@@ -95,5 +94,3 @@ open class HighlightableEditText(context: Context, attrs: AttributeSet) :
         }
     }
 }
-
-class HighlightSpan(@ColorInt color: Int) : BackgroundColorSpan(color)

--- a/app/src/main/java/com/philkes/notallyx/presentation/view/misc/highlightableview/HighlightableTextView.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/view/misc/highlightableview/HighlightableTextView.kt
@@ -1,0 +1,101 @@
+package com.philkes.notallyx.presentation.view.misc.highlightableview
+
+import android.content.Context
+import android.text.SpannableString
+import android.text.Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
+import android.text.TextUtils
+import android.util.AttributeSet
+import android.widget.TextView
+import androidx.appcompat.widget.AppCompatTextView
+import androidx.core.view.isVisible
+
+/** Amount of lines to show for a search snippet on top and below the keyword line */
+const val SEARCH_SNIPPET_ITEM_LINES = 2
+const val SEARCH_SNIPPET_SIZE = 100
+private const val ELLIPSED_TEXT = "..."
+
+/** TextView that can highlight keyword with snippet around it */
+class HighlightableTextView(context: Context, attrs: AttributeSet?) :
+    AppCompatTextView(context, attrs) {
+
+    fun clearHighlights() {
+        text = text.toString()
+    }
+
+    /** Visibly highlight text from [startIdx] to [endIdx]. */
+    fun highlight(keyword: String) {
+        val startIdx = this.text.indexOf(keyword, ignoreCase = true)
+        if (startIdx == -1) {
+            return
+        }
+        highlight(startIdx, startIdx + keyword.length)
+    }
+
+    fun highlight(startIdx: Int, endIdx: Int) {
+        this.text =
+            SpannableString(this.text.toString()).apply {
+                setSpan(HighlightSpan(highlightColor), startIdx, endIdx, SPAN_EXCLUSIVE_EXCLUSIVE)
+            }
+    }
+
+    fun showSearchSnippet(snippet: Snippet) {
+        val displayedText = buildString {
+            if (!snippet.includesFirstLine) append(ELLIPSED_TEXT)
+            append(snippet.text)
+            if (!snippet.includesLastLine) append(ELLIPSED_TEXT)
+        }
+        val displayKeywordIdx =
+            when {
+                !snippet.includesFirstLine -> snippet.keywordIdx + ELLIPSED_TEXT.length
+                else -> snippet.keywordIdx
+            }
+        text = displayedText
+        highlight(displayKeywordIdx, displayKeywordIdx + snippet.keyword.length)
+        isVisible = true
+        maxLines = Int.MAX_VALUE
+    }
+
+    /**
+     * Extract a snippet around given keyword that has given lines around the keyword.
+     *
+     * @return Snippet's text, keyword idx in the Snippet, whether or not the snippet includes the
+     *   first line of the text.
+     */
+    fun extractSearchSnippet(text: String, keyword: String): Snippet? {
+        val keywordIndex = text.indexOf(keyword, ignoreCase = true)
+        if (keywordIndex == -1) {
+            return null
+        }
+        if (text.length <= (2 * SEARCH_SNIPPET_SIZE) + keyword.length) {
+            return Snippet(text, keyword, text.indexOf(keyword, ignoreCase = true), true, true)
+        }
+        val start = (keywordIndex - SEARCH_SNIPPET_SIZE).coerceAtLeast(0)
+        val end = (keywordIndex + keyword.length + SEARCH_SNIPPET_SIZE).coerceAtMost(text.lastIndex)
+        val snippetText = text.substring(start, end + 1)
+        val keywordIdxInSnippet = snippetText.indexOf(keyword, ignoreCase = true)
+        return Snippet(snippetText, keyword, keywordIdxInSnippet, start == 0, end == text.lastIndex)
+    }
+
+    fun TextView.ellipsizeMultilineTextToFit(text: String): String {
+        val paint = paint
+        val availableWidth = width - paddingLeft - paddingRight
+        //        if (availableWidth <= 0) {
+        //            // Wait for layout if width not ready yet
+        //            post { ellipsizeMultilineTextToFit(text) }
+        //            return text
+        //        }
+
+        return text.lines().joinToString("\n") { line ->
+            TextUtils.ellipsize(line, paint, availableWidth.toFloat(), TextUtils.TruncateAt.END)
+                .toString()
+        }
+    }
+}
+
+data class Snippet(
+    val text: String,
+    val keyword: String,
+    val keywordIdx: Int,
+    val includesFirstLine: Boolean,
+    val includesLastLine: Boolean,
+)

--- a/app/src/main/java/com/philkes/notallyx/utils/changehistory/EditTextWithHistoryChange.kt
+++ b/app/src/main/java/com/philkes/notallyx/utils/changehistory/EditTextWithHistoryChange.kt
@@ -3,8 +3,8 @@ package com.philkes.notallyx.utils.changehistory
 import android.text.Editable
 import androidx.core.text.getSpans
 import com.philkes.notallyx.presentation.clone
-import com.philkes.notallyx.presentation.view.misc.HighlightSpan
 import com.philkes.notallyx.presentation.view.misc.StylableEditTextWithHistory
+import com.philkes.notallyx.presentation.view.misc.highlightableview.HighlightSpan
 
 class EditTextWithHistoryChange(
     private val editText: StylableEditTextWithHistory,

--- a/app/src/main/res/layout/recycler_base_note.xml
+++ b/app/src/main/res/layout/recycler_base_note.xml
@@ -80,7 +80,7 @@
           android:paddingEnd="16dp"
           app:layout_constraintTop_toBottomOf="@id/Space">
 
-            <TextView
+            <com.philkes.notallyx.presentation.view.misc.highlightableview.HighlightableTextView
               android:id="@+id/Title"
               android:layout_width="match_parent"
               android:layout_height="wrap_content"
@@ -151,7 +151,7 @@
                 />
         </LinearLayout>
 
-        <TextView
+        <com.philkes.notallyx.presentation.view.misc.highlightableview.HighlightableTextView
             android:id="@+id/Note"
             android:visibility="gone"
             android:layout_width="match_parent"
@@ -172,60 +172,60 @@
             android:paddingEnd="16dp"
             app:layout_constraintTop_toBottomOf="@id/Note">
 
-            <TextView
+            <com.philkes.notallyx.presentation.view.misc.highlightableview.HighlightableTextView
                 style="@style/FileChip.ListItem"
                 android:textIsSelectable="false"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content" />
 
-            <TextView
+            <com.philkes.notallyx.presentation.view.misc.highlightableview.HighlightableTextView
                 style="@style/FileChip.ListItem"
                 android:textIsSelectable="false"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content" />
 
-            <TextView
+            <com.philkes.notallyx.presentation.view.misc.highlightableview.HighlightableTextView
                 style="@style/FileChip.ListItem"
                 android:textIsSelectable="false"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content" />
 
-            <TextView
+            <com.philkes.notallyx.presentation.view.misc.highlightableview.HighlightableTextView
                 style="@style/FileChip.ListItem"
                 android:textIsSelectable="false"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content" />
 
-            <TextView
+            <com.philkes.notallyx.presentation.view.misc.highlightableview.HighlightableTextView
                 style="@style/FileChip.ListItem"
                 android:textIsSelectable="false"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content" />
 
-            <TextView
+            <com.philkes.notallyx.presentation.view.misc.highlightableview.HighlightableTextView
                 style="@style/FileChip.ListItem"
                 android:textIsSelectable="false"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content" />
 
-            <TextView
+            <com.philkes.notallyx.presentation.view.misc.highlightableview.HighlightableTextView
                 style="@style/FileChip.ListItem"
                 android:textIsSelectable="false"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content" />
 
-            <TextView
+            <com.philkes.notallyx.presentation.view.misc.highlightableview.HighlightableTextView
                 style="@style/FileChip.ListItem"
                 android:textIsSelectable="false"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content" />
 
-            <TextView
+            <com.philkes.notallyx.presentation.view.misc.highlightableview.HighlightableTextView
                 style="@style/FileChip.ListItem"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content" />
 
-            <TextView
+            <com.philkes.notallyx.presentation.view.misc.highlightableview.HighlightableTextView
                 style="@style/FileChip.ListItem"
                 android:textIsSelectable="false"
                 android:layout_width="match_parent"


### PR DESCRIPTION
Closes #158

This PR improves the search note functionality.

- The found keyword is highlighted in the found notes' previews ( a certrain amount of characters/listitems around the found keyword is also displayed)
- When entering a note from search view, the found keyword is highlighted immediately

For Text Note:

[notallyx_issues_158_notes.webm](https://github.com/user-attachments/assets/70ac944d-7161-4150-9ac0-34b8bd8e21ec)

For List Note:

[notallyx_issues_158_lists.webm](https://github.com/user-attachments/assets/e096e87d-1cc9-42ab-a971-37e350253359)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Editor opens with the current search query auto-filled and highlighted.
  * Notes/list items display focused search snippets with keyword highlighting.

* **Improvements**
  * Search keywords now propagate consistently between search, list, and editor.
  * Search input and back-key handling improved; list scrolls to top on query changes.

* **UI**
  * Text rendering updated to emphasize matched terms and show remaining-item indicators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->