### PR TITLE
fix: correct docs link in app and in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <h2 align="center">
     <img src="fastlane/metadata/android/en-US/images/icon.png" alt="icon" width="90"/>
     <br />
-    <b><a href="https://philkes.github.io/NotallyX/">NotallyX | Minimalistic note taking app</a></b>
+    <b><a href="https://crustack.github.io/NotallyX/">NotallyX | Minimalistic note taking app</a></b>
     <p>
         <center>
             <a href="https://ko-fi.com/philkes"><img alt='Donate' height='30' src='documentation/static/img/kofi_donate.svg' /></a>
@@ -32,7 +32,7 @@
 ### Features
 [Notally](https://github.com/OmGodse/Notally), but eXtended
 
-<h4><a href="https://philkes.github.io/NotallyX/">See Documentation</a></h4>
+<h4><a href="https://crustack.github.io/NotallyX/">See Documentation</a></h4>
 
 * Create **rich text** notes with support for bold, italics, mono space and strike-through
 * Create **task lists** and order them with subtasks (+ auto-sort checked items to the end)

--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/main/fragment/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/main/fragment/settings/SettingsFragment.kt
@@ -772,7 +772,7 @@ class SettingsFragment : Fragment() {
             Rate.setOnClickListener {
                 openLink("https://play.google.com/store/apps/details?id=com.philkes.notallyx")
             }
-            Documentation.setOnClickListener { openLink("https://philkes.github.io/NotallyX") }
+            Documentation.setOnClickListener { openLink("https://crustack.github.io/NotallyX") }
             SourceCode.setOnClickListener { openLink("https://github.com/Crustack/NotallyX") }
             Libraries.setOnClickListener {
                 val libraries =
@@ -933,7 +933,7 @@ class SettingsFragment : Fragment() {
     }
 
     private fun openDocsLink(docPath: String) {
-        openLink("https://philkes.github.io/NotallyX/docs/$docPath")
+        openLink("https://crustack.github.io/NotallyX/docs/$docPath")
     }
 
     private fun askForUriPermissions(uri: Uri) {


### PR DESCRIPTION
Let me know if i should replace all philkes links to crustack.

I was unable to visit the docs from the app directly so i had to check upstream link.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation links to point to a new domain throughout the application and documentation files.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->