### PR TITLE
Properly set selectedExportMimeType for in-note export

### DIFF
--- a/app/src/main/java/com/philkes/notallyx/utils/backup/ExportExtensions.kt
+++ b/app/src/main/java/com/philkes/notallyx/utils/backup/ExportExtensions.kt
@@ -900,6 +900,7 @@ fun LockedActivity<*>.exportNote(
     mimeType: ExportMimeType,
     exportToFileResultLauncher: ActivityResultLauncher<Intent>,
 ) {
+    baseModel.selectedExportMimeType = mimeType
     val suggestedName =
         (note.title.ifBlank { getString(R.string.note) }) + "." + mimeType.fileExtension
     val intent =


### PR DESCRIPTION
Fixes #772 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the selected export format was not properly retained when exporting notes, ensuring users' export preferences are consistently saved during export operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->