### PR TITLE
Fix toReadablePath if fromTreeUri fails

### DIFF
--- a/app/src/main/java/com/philkes/notallyx/utils/AndroidExtensions.kt
+++ b/app/src/main/java/com/philkes/notallyx/utils/AndroidExtensions.kt
@@ -533,7 +533,13 @@ fun Context.toReadablePath(uri: Uri): String {
     if (uri.authority == "com.android.externalstorage.documents") {
         return toReadable(uri.path!!)
     }
-    val documentFile = DocumentFile.fromTreeUri(this, uri)
+
+    val documentFile =
+        try {
+            DocumentFile.fromTreeUri(this, uri)
+        } catch (_: Exception) {
+            null
+        }
     return documentFile?.name?.let { "${uri.authority}/$it" }
         ?: uri.path?.let { toReadable(it) }
         ?: uri.toString()


### PR DESCRIPTION
Fixes #786 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for file operations to prevent crashes when certain file system interactions fail. The app now gracefully falls back to alternative path handling instead of crashing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->