### PR TITLE
fix: prevent SQLiteBlobTooBig crash from oversized note body on app open

### DIFF
--- a/app/src/main/java/com/philkes/notallyx/data/NotallyDatabase.kt
+++ b/app/src/main/java/com/philkes/notallyx/data/NotallyDatabase.kt
@@ -33,7 +33,7 @@ import java.io.File
 import net.zetetic.database.sqlcipher.SupportOpenHelperFactory
 
 @TypeConverters(Converters::class)
-@Database(entities = [BaseNote::class, Label::class], version = 9)
+@Database(entities = [BaseNote::class, Label::class], version = 10)
 abstract class NotallyDatabase : RoomDatabase() {
 
     abstract fun getLabelDao(): LabelDao
@@ -144,18 +144,7 @@ abstract class NotallyDatabase : RoomDatabase() {
                         Migration7,
                         Migration8,
                         Migration9,
-                    )
-                    .addCallback(
-                        object : RoomDatabase.Callback() {
-                            override fun onOpen(db: SupportSQLiteDatabase) {
-                                super.onOpen(db)
-                                // Safety repair for legacy/externally-imported rows that can exceed
-                                // CursorWindow limits and crash note list loading.
-                                db.execSQL(
-                                    "UPDATE BaseNote SET body = substr(body, 1, $MAX_BODY_CHAR_LENGTH) WHERE length(body) > $MAX_BODY_CHAR_LENGTH"
-                                )
-                            }
-                        }
+                        Migration10,
                     )
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
                 System.loadLibrary("sqlcipher")
@@ -292,6 +281,16 @@ abstract class NotallyDatabase : RoomDatabase() {
             override fun migrate(db: SupportSQLiteDatabase) {
                 db.execSQL(
                     "ALTER TABLE `BaseNote` ADD COLUMN `viewMode` TEXT NOT NULL DEFAULT '${NoteViewMode.EDIT.name}'"
+                )
+            }
+        }
+
+        object Migration10 : Migration(9, 10) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                // One-shot repair for legacy/imported oversized notes that can trigger
+                // SQLiteBlobTooBigException during list queries.
+                db.execSQL(
+                    "UPDATE BaseNote SET body = substr(body, 1, $MAX_BODY_CHAR_LENGTH) WHERE length(body) > $MAX_BODY_CHAR_LENGTH"
                 )
             }
         }


### PR DESCRIPTION
## Summary
Fixes the crash loop reported in #837 ().

## Root cause
A legacy/imported oversized  row can exceed CursorWindow limits during list reads (), causing Room LiveData query failures and making notes inaccessible.

## Change (targeted)
- File changed: 
- Added a **Room  callback** that runs:



This is intentionally minimal and only touches rows above the existing app-defined size limit.

## Why this helps
- Breaks the crash loop on startup/list loading
- Preserves accessibility to existing notes
- Uses existing max-body policy already enforced in app write paths

## Notes
I could not run local Gradle compilation in this environment because Java runtime is unavailable ().
Code change is Kotlin-only, scoped to DB open safety repair.

Fixes #837

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added an automatic data repair during upgrade that truncates note bodies exceeding the supported length, preventing errors from oversized content.
  * Database upgrade now includes this repair step so existing notes are corrected on first launch after updating, improving stability and data integrity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->