### PR TITLE
MaterialDatePicker timezone bug

### DIFF
--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/note/reminders/DatePickerFragment.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/note/reminders/DatePickerFragment.kt
@@ -6,6 +6,7 @@ import com.google.android.material.datepicker.MaterialDatePicker
 import com.philkes.notallyx.utils.now
 import java.util.Calendar
 import java.util.Date
+import java.util.TimeZone
 
 class DatePickerFragment(
     private val date: Date?,
@@ -21,7 +22,7 @@ class DatePickerFragment(
             MaterialDatePicker.Builder.datePicker().setSelection(c.timeInMillis).build()
 
         datePicker.addOnPositiveButtonClickListener { selection ->
-            val calendar = Calendar.getInstance()
+            val calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"))
             calendar.timeInMillis = selection
             onDateSetListener(
                 calendar.get(Calendar.YEAR),


### PR DESCRIPTION
The bug is that the reminder is set to a day before of my date.
To reproduce this bug you have to have a specific timezone and hour, in my case I tested with GMT-3 and 11:00 AM, after this you just create a reminder.
I read that MaterialDatePicker timezone is UTC, and Calendar.getInstance() choose the timezone of the device, so I think this bug is happening because my timezone is GMT-3.
I tested with this change and it worked.

<video  src="https://github.com/user-attachments/assets/03baa09e-0289-4f25-8852-20f016ce445e"  controls></video>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed timezone handling in date picker to use UTC timezone for consistent date selection across different regions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->