### PR TITLE
Clear note reminders

### DIFF
--- a/app/src/main/java/com/philkes/notallyx/data/dao/BaseNoteDao.kt
+++ b/app/src/main/java/com/philkes/notallyx/data/dao/BaseNoteDao.kt
@@ -222,6 +222,9 @@ interface BaseNoteDao {
     @Query("UPDATE BaseNote SET reminders = :reminders WHERE id = :id")
     suspend fun updateReminders(id: Long, reminders: List<Reminder>)
 
+    @Query("UPDATE BaseNote SET reminders = '[]' WHERE id IN (:ids)")
+    suspend fun clearReminders(ids: LongArray)
+
     @Query("UPDATE BaseNote SET spans = :spans WHERE id = :id")
     suspend fun updateSpans(
         id: Long,

--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/note/NoteActionHandler.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/note/NoteActionHandler.kt
@@ -320,7 +320,10 @@ class NoteActionHandler(
     }
 
     private fun delete() {
-        moveNote(Folder.DELETED)
+        activity.lifecycleScope.launch {
+            notallyModel.clearReminders()
+            moveNote(Folder.DELETED)
+        }
     }
 
     private fun restore() {

--- a/app/src/main/java/com/philkes/notallyx/presentation/viewmodel/BaseNoteModel.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/viewmodel/BaseNoteModel.kt
@@ -645,6 +645,7 @@ class BaseNoteModel(private val app: Application) : AndroidViewModel(app) {
         ) { // Only reminders of notes in NOTES folder are active
             if (folder == Folder.DELETED) {
                 baseNoteDao.move(ids, folder, System.currentTimeMillis())
+                baseNoteDao.clearReminders(ids)
             } else {
                 baseNoteDao.move(ids, folder)
             }

--- a/app/src/main/java/com/philkes/notallyx/presentation/viewmodel/NotallyModel.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/viewmodel/NotallyModel.kt
@@ -452,6 +452,11 @@ class NotallyModel(private val app: Application) : AndroidViewModel(app) {
         withContext(Dispatchers.IO) { baseNoteDao.updateReminders(id, updatedReminders) }
     }
 
+    suspend fun clearReminders() {
+        app.cancelNoteReminders(listOf(NoteIdReminder(id, reminders.value)))
+        updateReminders(emptyList())
+    }
+
     suspend fun convertTo(noteType: Type) {
         when (noteType) {
             Type.NOTE -> {


### PR DESCRIPTION
#912 

The only problem is that all notes that have already been deleted will keep their reminders; this will only affect newly deleted notes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where reminders were not being cleared when notes were deleted, preventing orphaned reminders from triggering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->