### PR TITLE
fix: cancel reminders when note is moved to deleted or archived folder in edit screen

### DIFF
--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/note/NoteActionHandler.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/note/NoteActionHandler.kt
@@ -17,6 +17,7 @@ import androidx.lifecycle.lifecycleScope
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.philkes.notallyx.R
 import com.philkes.notallyx.data.NotallyDatabase
+import com.philkes.notallyx.data.dao.NoteIdReminder
 import com.philkes.notallyx.data.model.Audio
 import com.philkes.notallyx.data.model.ColorString
 import com.philkes.notallyx.data.model.FileAttachment
@@ -39,6 +40,7 @@ import com.philkes.notallyx.presentation.viewmodel.ExportMimeType
 import com.philkes.notallyx.presentation.viewmodel.NotallyModel
 import com.philkes.notallyx.presentation.viewmodel.preference.EditAction
 import com.philkes.notallyx.utils.backup.exportNote
+import com.philkes.notallyx.utils.cancelNoteReminders
 import com.philkes.notallyx.utils.openNote
 import com.philkes.notallyx.utils.shareNote
 import com.philkes.notallyx.utils.showColorSelectDialog
@@ -338,6 +340,11 @@ class NoteActionHandler(
     }
 
     private fun moveNote(toFolder: Folder) {
+        if (toFolder != Folder.NOTES) {
+            val noteIdReminders: List<NoteIdReminder> =
+                listOf(NoteIdReminder(notallyModel.id, notallyModel.reminders.value))
+            this.activity.cancelNoteReminders(noteIdReminders)
+        }
         val resultIntent =
             Intent().apply {
                 putExtra(EditActivity.EXTRA_NOTE_ID, notallyModel.id)


### PR DESCRIPTION
The bug is that the reminder still notify even after I delete a note in the edit screen.
This doesn't happen when I delete notes in the action mode (when selecting multiple notes to delete).

I notice that in the BaseNoteModel.kt has this code:
```kotlin
when (folder) {
    Folder.NOTES -> app.scheduleNoteReminders(notes)
    else -> app.cancelNoteReminders(notes)
}
```

But in the edit note screen, the code only moves the note to the deleted folder without cancelling the reminders.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed reminder behavior when moving notes to different folders—reminders are now automatically cancelled when moving a note outside the main notes folder.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->