### PR TITLE
Ignore FileAlreadyExistsException in File.createDirectory

### DIFF
--- a/app/src/main/java/com/philkes/notallyx/utils/IOExtensions.kt
+++ b/app/src/main/java/com/philkes/notallyx/utils/IOExtensions.kt
@@ -23,6 +23,7 @@ import com.philkes.notallyx.presentation.widget.WidgetProvider
 import java.io.File
 import java.io.FileFilter
 import java.io.FileOutputStream
+import java.io.IOException
 import java.io.InputStream
 import java.io.OutputStream
 import java.nio.file.FileAlreadyExistsException
@@ -372,7 +373,13 @@ private fun File.createDirectory() {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
         try {
             Files.createDirectory(toPath())
-        } catch (_: FileAlreadyExistsException) {}
+        } catch (e: FileAlreadyExistsException) {
+            if (!isDirectory)
+                throw IOException(
+                    "Creating directory '${toPath()}' did not work because a file with that name already exists and was not properly deleted",
+                    e,
+                )
+        }
     } else mkdir()
 }
 

--- a/app/src/main/java/com/philkes/notallyx/utils/IOExtensions.kt
+++ b/app/src/main/java/com/philkes/notallyx/utils/IOExtensions.kt
@@ -25,6 +25,7 @@ import java.io.FileFilter
 import java.io.FileOutputStream
 import java.io.InputStream
 import java.io.OutputStream
+import java.nio.file.FileAlreadyExistsException
 import java.nio.file.Files
 import java.security.MessageDigest
 import java.util.zip.CRC32
@@ -369,7 +370,9 @@ private fun getDirectory(dir: File, name: String): File {
 
 private fun File.createDirectory() {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-        Files.createDirectory(toPath())
+        try {
+            Files.createDirectory(toPath())
+        } catch (_: FileAlreadyExistsException) {}
     } else mkdir()
 }
 


### PR DESCRIPTION
Fixes #965 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved directory creation on Android 26+ to avoid spurious errors when the target already exists as a directory, reducing file-system failures; behavior on older Android versions is unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->