### PR TITLE
Fix edit note reload on open intent

### DIFF
--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/note/EditActivity.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/note/EditActivity.kt
@@ -160,6 +160,12 @@ abstract class EditActivity(private val type: Type) : LockedActivity<ActivityEdi
         }
     }
 
+    override fun onNewIntent(intent: Intent?) {
+        super.onNewIntent(intent)
+        val selectedId = intent?.getLongExtra(EXTRA_SELECTED_BASE_NOTE, 0L) ?: 0L
+        lifecycleScope.launch { loadNote(selectedId, null, null) }
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         actionHandler.setupActivityResultLaunchers()
@@ -175,39 +181,7 @@ abstract class EditActivity(private val type: Type) : LockedActivity<ActivityEdi
             val persistedId = savedInstanceState?.getLong("id")
             val selectedId = intent.getLongExtra(EXTRA_SELECTED_BASE_NOTE, 0L)
             val id = persistedId ?: selectedId
-            if (persistedId == null || notallyModel.originalNote == null) {
-                notallyModel.setState(id, intent.data == null)
-            }
-            if (notallyModel.isNewNote) {
-                when (intent.action) {
-                    Intent.ACTION_SEND,
-                    Intent.ACTION_SEND_MULTIPLE,
-                    Intent.ACTION_VIEW -> handleSharedNote()
-                    else ->
-                        intent.getStringExtra(EXTRA_DISPLAYED_LABEL)?.let {
-                            notallyModel.setLabels(listOf(it))
-                        }
-                }
-            }
-
-            initBottomMenu()
-            resetToolbars()
-            setupListeners()
-            setStateFromModel(savedInstanceState)
-
-            if (
-                !notallyModel.isNewNote &&
-                    notallyModel.type == Type.LIST &&
-                    savedInstanceState == null
-            ) {
-                val lastUsedViewMode = notallyModel.viewMode.value
-                notallyModel.viewMode.value =
-                    preferences.defaultListNoteViewMode.value.toNoteViewMode(lastUsedViewMode)
-            }
-
-            configureUI()
-            binding.ScrollView.visibility = VISIBLE
-            setupEditNoteReminderChip()
+            loadNote(id, persistedId, savedInstanceState)
         }
 
         Thread.setDefaultUncaughtExceptionHandler { thread, throwable ->
@@ -221,6 +195,42 @@ abstract class EditActivity(private val type: Type) : LockedActivity<ActivityEdi
                 DEFAULT_EXCEPTION_HANDLER?.uncaughtException(thread, throwable)
             }
         }
+    }
+
+    private suspend fun loadNote(id: Long, persistedId: Long?, savedInstanceState: Bundle?) {
+        changeHistory.reset()
+        if (persistedId == null || notallyModel.originalNote == null) {
+            notallyModel.setState(id, intent.data == null)
+        }
+        if (notallyModel.isNewNote) {
+            when (intent.action) {
+                Intent.ACTION_SEND,
+                Intent.ACTION_SEND_MULTIPLE,
+                Intent.ACTION_VIEW -> handleSharedNote()
+
+                else ->
+                    intent.getStringExtra(EXTRA_DISPLAYED_LABEL)?.let {
+                        notallyModel.setLabels(listOf(it))
+                    }
+            }
+        }
+
+        initBottomMenu()
+        resetToolbars()
+        setupListeners()
+        setStateFromModel(savedInstanceState)
+
+        if (
+            !notallyModel.isNewNote && notallyModel.type == Type.LIST && savedInstanceState == null
+        ) {
+            val lastUsedViewMode = notallyModel.viewMode.value
+            notallyModel.viewMode.value =
+                preferences.defaultListNoteViewMode.value.toNoteViewMode(lastUsedViewMode)
+        }
+
+        configureUI()
+        binding.ScrollView.visibility = VISIBLE
+        setupEditNoteReminderChip()
     }
 
     override fun onRestart() {

--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/note/EditActivity.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/note/EditActivity.kt
@@ -168,7 +168,7 @@ abstract class EditActivity(private val type: Type) : LockedActivity<ActivityEdi
         if (selectedId != -1L) {
             lifecycleScope.launch {
                 checkSave()
-                loadNote(selectedId, null, null)
+                loadNote(selectedId, null, null, false)
             }
         }
     }
@@ -188,10 +188,8 @@ abstract class EditActivity(private val type: Type) : LockedActivity<ActivityEdi
             val persistedId = savedInstanceState?.getLong("id")
             val selectedId = intent.getLongExtra(EXTRA_SELECTED_BASE_NOTE, 0L)
             val id = persistedId ?: selectedId
-            loadNote(id, persistedId, savedInstanceState)
+            loadNote(id, persistedId, savedInstanceState, true)
         }
-        setupListeners()
-        configureUI()
         Thread.setDefaultUncaughtExceptionHandler { thread, throwable ->
             try {
                 updateModel()
@@ -205,7 +203,12 @@ abstract class EditActivity(private val type: Type) : LockedActivity<ActivityEdi
         }
     }
 
-    private suspend fun loadNote(id: Long, persistedId: Long?, savedInstanceState: Bundle?) {
+    private suspend fun loadNote(
+        id: Long,
+        persistedId: Long?,
+        savedInstanceState: Bundle?,
+        initListeners: Boolean,
+    ) {
         changeHistory.reset()
         if (persistedId == null || notallyModel.originalNote == null) {
             notallyModel.setState(id, intent.data == null)
@@ -225,6 +228,7 @@ abstract class EditActivity(private val type: Type) : LockedActivity<ActivityEdi
 
         initBottomMenu()
         resetToolbars()
+        if (initListeners) setupListeners()
         setStateFromModel(savedInstanceState)
 
         if (
@@ -234,7 +238,7 @@ abstract class EditActivity(private val type: Type) : LockedActivity<ActivityEdi
             notallyModel.viewMode.value =
                 preferences.defaultListNoteViewMode.value.toNoteViewMode(lastUsedViewMode)
         }
-
+        if (initListeners) configureUI()
         binding.ScrollView.visibility = VISIBLE
         setupEditNoteReminderChip()
     }

--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/note/EditActivity.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/note/EditActivity.kt
@@ -190,7 +190,8 @@ abstract class EditActivity(private val type: Type) : LockedActivity<ActivityEdi
             val id = persistedId ?: selectedId
             loadNote(id, persistedId, savedInstanceState)
         }
-
+        setupListeners()
+        configureUI()
         Thread.setDefaultUncaughtExceptionHandler { thread, throwable ->
             try {
                 updateModel()
@@ -224,7 +225,6 @@ abstract class EditActivity(private val type: Type) : LockedActivity<ActivityEdi
 
         initBottomMenu()
         resetToolbars()
-        setupListeners()
         setStateFromModel(savedInstanceState)
 
         if (
@@ -235,7 +235,6 @@ abstract class EditActivity(private val type: Type) : LockedActivity<ActivityEdi
                 preferences.defaultListNoteViewMode.value.toNoteViewMode(lastUsedViewMode)
         }
 
-        configureUI()
         binding.ScrollView.visibility = VISIBLE
         setupEditNoteReminderChip()
     }

--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/note/EditActivity.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/note/EditActivity.kt
@@ -162,8 +162,15 @@ abstract class EditActivity(private val type: Type) : LockedActivity<ActivityEdi
 
     override fun onNewIntent(intent: Intent?) {
         super.onNewIntent(intent)
-        val selectedId = intent?.getLongExtra(EXTRA_SELECTED_BASE_NOTE, 0L) ?: 0L
-        lifecycleScope.launch { loadNote(selectedId, null, null) }
+        if (intent == null) return
+        setIntent(intent)
+        val selectedId = intent.getLongExtra(EXTRA_SELECTED_BASE_NOTE, -1L)
+        if (selectedId != -1L) {
+            lifecycleScope.launch {
+                checkSave()
+                loadNote(selectedId, null, null)
+            }
+        }
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/note/reminders/ReminderReceiver.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/note/reminders/ReminderReceiver.kt
@@ -138,16 +138,21 @@ class ReminderReceiver : BroadcastReceiver() {
                 PinnedNotificationManager.notify(context, note)
             }
             context.getSystemService<NotificationManager>()?.let { manager ->
-                manager.activeNotifications.ofNote(noteId).forEach { notification ->
-                    val reminderId = notification.id
-                    Log.d(TAG, "Updating notification for noteId: $noteId reminderId: $reminderId")
-                    notify(
-                        context,
-                        noteId,
-                        reminderId.toLong(),
-                        schedule = false,
-                        isOnlyUpdate = true,
-                    )
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                    manager.activeNotifications.ofNote(noteId).forEach { notification ->
+                        val reminderId = notification.id
+                        Log.d(
+                            TAG,
+                            "Updating notification for noteId: $noteId reminderId: $reminderId",
+                        )
+                        notify(
+                            context,
+                            noteId,
+                            reminderId.toLong(),
+                            schedule = false,
+                            isOnlyUpdate = true,
+                        )
+                    }
                 }
             }
             //            val mostRecentReminder = note.reminders.findLastNotified() ?: return

--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/note/reminders/ReminderReceiver.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/note/reminders/ReminderReceiver.kt
@@ -194,6 +194,9 @@ class ReminderReceiver : BroadcastReceiver() {
             )
         }
         database.getBaseNoteDao().get(noteId)?.let { note ->
+            if (note.folder != Folder.NOTES) {
+                return@let
+            }
             val deleteNoteIntent =
                 Intent(context, ReminderReceiver::class.java).apply {
                     action = ACTION_DELETE_NOTE

--- a/app/src/main/java/com/philkes/notallyx/utils/changehistory/ChangeHistory.kt
+++ b/app/src/main/java/com/philkes/notallyx/utils/changehistory/ChangeHistory.kt
@@ -70,8 +70,8 @@ class ChangeHistory(
     }
 
     fun reset() {
-        stackPointer.value = -1
         changeStack.clear()
+        stackPointer.value = -1
     }
 
     internal fun lookUp(position: Int = 0): Change {


### PR DESCRIPTION
Fixes #981 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reminder/notification logic now avoids unsupported notification access on older Android versions and skips notifications for non-note items, improving reliability.

* **Refactor**
  * In-place note loading and live note switching now reloads a different selected note without reinitializing the UI, and performs an async save/check before switching for smoother transitions.
  * Change history reset order adjusted for more consistent undo/redo behavior and fewer unexpected intermediate states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->