### PR TITLE
Log WebView load errors when exporting a note to PDF

### DIFF
--- a/app/src/main/java/android/print/PdfExtensions.kt
+++ b/app/src/main/java/android/print/PdfExtensions.kt
@@ -2,10 +2,13 @@ package android.print
 
 import android.content.ContentResolver
 import android.content.Context
+import android.util.Log
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.documentfile.provider.DocumentFile
 import com.philkes.notallyx.utils.nameWithoutExtension
+
+private const val TAG = "PdfExtensions"
 
 /**
  * Needs to be in android.print package to access the package private methods of
@@ -20,6 +23,16 @@ fun Context.printPdf(file: DocumentFile, content: String, pdfPrintListener: PdfP
             override fun onPageFinished(view: WebView?, url: String?) {
                 val adapter = webView.createPrintDocumentAdapter(file.nameWithoutExtension!!)
                 contentResolver.printPdf(file, adapter, pdfPrintListener)
+            }
+
+            @Suppress("DEPRECATION")
+            override fun onReceivedError(
+                view: WebView?,
+                errorCode: Int,
+                description: String?,
+                failingUrl: String?,
+            ) {
+                Log.w(TAG, "PDF WebView load error $errorCode: $description @ $failingUrl")
             }
         }
 }


### PR DESCRIPTION
Closes #1036

### What this does

Adds a single `onReceivedError(view, errorCode, description, failingUrl)` override to the `WebViewClient` used in `Context.printPdf(...)` in `app/src/main/java/android/print/PdfExtensions.kt`. It logs the error code, description and failing URL with `Log.w`. Adds a small file-level `private const val TAG = "PdfExtensions"`.

No behaviour change in the happy path. No new dependencies.

### Why

`onPageFinished` currently fires regardless of whether the load succeeded, so a print that ended up with missing assets ships through `createPrintDocumentAdapter(...)` and produces a half-rendered PDF with no logcat trace. This override makes the failure visible so future "exported PDF is missing parts" reports have something concrete to look at.

### Note on the signature

I used the deprecated 4-arg form rather than the API 23+ `(WebView, WebResourceRequest, WebResourceError)` overload on purpose. The app's `minSdk` is 21 and the framework dispatches the deprecated form on every API level when nothing else is overridden, so this single override actually fires for every user. Happy to switch to the new signature gated on `Build.VERSION.SDK_INT >= M` if you would prefer that style.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added error logging for PDF printing operations to capture detailed error information during failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Crustack/NotallyX/pull/1037?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->