### PR TITLE
Move finding search results to default dispatcher

### DIFF
--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/note/EditActivity.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/note/EditActivity.kt
@@ -90,6 +90,7 @@ import com.philkes.notallyx.utils.textMaxLengthFilter
 import com.philkes.notallyx.utils.wrapWithChooser
 import java.io.File
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 
@@ -421,20 +422,24 @@ abstract class EditActivity(private val type: Type) : LockedActivity<ActivityEdi
         updateBottomActions(preferences.editNoteActivityBottomAction.value)
     }
 
+    private var searchJob: Job? = null
+
     protected fun updateSearchResults(query: String) {
         val amountBefore = search.results.value
-        lifecycleScope.launch {
-            val amount = highlightSearchResults(query)
-            this@EditActivity.search.results.value = amount
-            if (amount > 0) {
-                search.resultPos.value =
-                    when {
-                        amountBefore < 1 -> 0
-                        search.resultPos.value >= amount -> amount - 1
-                        else -> search.resultPos.value
-                    }
+        searchJob?.cancel()
+        searchJob =
+            lifecycleScope.launch {
+                val amount = highlightSearchResults(query)
+                this@EditActivity.search.results.value = amount
+                if (amount > 0) {
+                    search.resultPos.value =
+                        when {
+                            amountBefore < 1 -> 0
+                            search.resultPos.value >= amount -> amount - 1
+                            else -> search.resultPos.value
+                        }
+                }
             }
-        }
     }
 
     /**

--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/note/EditActivity.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/note/EditActivity.kt
@@ -684,8 +684,11 @@ abstract class EditActivity(private val type: Type) : LockedActivity<ActivityEdi
 
         binding.EnterSearchKeyword.apply {
             doAfterTextChanged { text ->
-                this@EditActivity.search.query = text.toString()
-                updateSearchResults(this@EditActivity.search.query)
+                val textStr = text.toString()
+                if (this@EditActivity.search.query != textStr) {
+                    this@EditActivity.search.query = textStr
+                    updateSearchResults(this@EditActivity.search.query)
+                }
             }
         }
         setupAdditionalListeners()

--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/note/EditActivity.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/note/EditActivity.kt
@@ -423,15 +423,17 @@ abstract class EditActivity(private val type: Type) : LockedActivity<ActivityEdi
 
     protected fun updateSearchResults(query: String) {
         val amountBefore = search.results.value
-        val amount = highlightSearchResults(query)
-        this.search.results.value = amount
-        if (amount > 0) {
-            search.resultPos.value =
-                when {
-                    amountBefore < 1 -> 0
-                    search.resultPos.value >= amount -> amount - 1
-                    else -> search.resultPos.value
-                }
+        lifecycleScope.launch {
+            val amount = highlightSearchResults(query)
+            this@EditActivity.search.results.value = amount
+            if (amount > 0) {
+                search.resultPos.value =
+                    when {
+                        amountBefore < 1 -> 0
+                        search.resultPos.value >= amount -> amount - 1
+                        else -> search.resultPos.value
+                    }
+            }
         }
     }
 
@@ -440,7 +442,7 @@ abstract class EditActivity(private val type: Type) : LockedActivity<ActivityEdi
      *
      * @return amount of search results found
      */
-    abstract fun highlightSearchResults(search: String): Int
+    abstract suspend fun highlightSearchResults(search: String): Int
 
     abstract fun selectSearchResult(resultPos: Int)
 

--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/note/EditListActivity.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/note/EditListActivity.kt
@@ -27,8 +27,10 @@ import com.philkes.notallyx.presentation.viewmodel.preference.autoSortByCheckedE
 import com.philkes.notallyx.presentation.viewmodel.preference.callback
 import com.philkes.notallyx.utils.findAllOccurrences
 import com.philkes.notallyx.utils.indices
-import com.philkes.notallyx.utils.mapIndexed
+import com.philkes.notallyx.utils.mapIndexedSuspended
 import java.util.concurrent.atomic.AtomicInteger
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 class EditListActivity : EditActivity(Type.LIST) {
 
@@ -104,14 +106,15 @@ class EditListActivity : EditActivity(Type.LIST) {
             .show(supportFragmentManager, MoreListBottomSheet.TAG)
     }
 
-    private fun SortedList<ListItem>.highlightSearch(
+    private suspend fun SortedList<ListItem>.highlightSearch(
         search: String,
         adapter: HighlightText?,
         resultPosCounter: AtomicInteger,
         alreadyNotifiedItemPos: MutableSet<Int>,
     ): Int {
-        return mapIndexed { idx, item ->
-                val occurrences = item.body.findAllOccurrences(search)
+        return mapIndexedSuspended { idx, item ->
+                val occurrences =
+                    withContext(Dispatchers.Default) { item.body.findAllOccurrences(search) }
                 occurrences.onEach { (startIdx, endIdx) ->
                     adapter?.highlightText(
                         ListItemHighlight(
@@ -131,14 +134,15 @@ class EditListActivity : EditActivity(Type.LIST) {
             .sum()
     }
 
-    private fun List<ListItem>.highlightSearch(
+    private suspend fun List<ListItem>.highlightSearch(
         search: String,
         adapter: ListItemAdapter?,
         resultPosCounter: AtomicInteger,
         alreadyNotifiedItemPos: MutableSet<Int>,
     ): Int {
-        return mapIndexed { idx, item ->
-                val occurrences = item.body.findAllOccurrences(search)
+        return mapIndexedSuspended { idx, item ->
+                val occurrences =
+                    withContext(Dispatchers.Default) { item.body.findAllOccurrences(search) }
                 occurrences.onEach { (startIdx, endIdx) ->
                     adapter?.highlightText(
                         ListItemHighlight(
@@ -158,7 +162,7 @@ class EditListActivity : EditActivity(Type.LIST) {
             .sum()
     }
 
-    override fun highlightSearchResults(search: String): Int {
+    override suspend fun highlightSearchResults(search: String): Int {
         val resultPosCounter = AtomicInteger(0)
         val alreadyNotifiedItemPos = mutableSetOf<Int>()
         adapter?.clearHighlights()

--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/note/EditNoteActivity.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/note/EditNoteActivity.kt
@@ -81,10 +81,8 @@ class EditNoteActivity : EditActivity(Type.NOTE) {
         }
         val text = notallyModel.body.toString()
         val occurrences = withContext(Dispatchers.Default) { text.findAllOccurrences(search) }
-        searchResultIndices =
-            occurrences.onEach { (startIdx, endIdx) ->
-                binding.EnterBody.highlight(startIdx, endIdx, false)
-            }
+        binding.EnterBody.highlight(occurrences, -1)
+        searchResultIndices = occurrences
         return searchResultIndices!!.size
     }
 
@@ -94,7 +92,7 @@ class EditNoteActivity : EditActivity(Type.NOTE) {
             return
         }
         searchResultIndices?.get(resultPos)?.let { (startIdx, endIdx) ->
-            val selectedLineTop = binding.EnterBody.highlight(startIdx, endIdx, true)
+            val selectedLineTop = binding.EnterBody.select(startIdx, endIdx)
             selectedLineTop?.let { binding.ScrollView.scrollTo(0, it) }
         }
     }

--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/note/EditNoteActivity.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/note/EditNoteActivity.kt
@@ -36,6 +36,8 @@ import com.philkes.notallyx.utils.copyToClipBoard
 import com.philkes.notallyx.utils.findAllOccurrences
 import com.philkes.notallyx.utils.openNote
 import com.philkes.notallyx.utils.wrapWithChooser
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 class EditNoteActivity : EditActivity(Type.NOTE) {
 
@@ -72,13 +74,15 @@ class EditNoteActivity : EditActivity(Type.NOTE) {
         }
     }
 
-    override fun highlightSearchResults(search: String): Int {
+    override suspend fun highlightSearchResults(search: String): Int {
         binding.EnterBody.clearHighlights()
         if (search.isEmpty()) {
             return 0
         }
+        val text = notallyModel.body.toString()
+        val occurrences = withContext(Dispatchers.Default) { text.findAllOccurrences(search) }
         searchResultIndices =
-            notallyModel.body.toString().findAllOccurrences(search).onEach { (startIdx, endIdx) ->
+            occurrences.onEach { (startIdx, endIdx) ->
                 binding.EnterBody.highlight(startIdx, endIdx, false)
             }
         return searchResultIndices!!.size

--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/note/EditTextPlainActivity.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/note/EditTextPlainActivity.kt
@@ -111,10 +111,8 @@ class EditTextPlainActivity : EditActivity(Type.NOTE) {
         }
         val text = notallyModel.body.toString()
         val occurrences = withContext(Dispatchers.Default) { text.findAllOccurrences(search) }
-        searchResultIndices =
-            occurrences.onEach { (startIdx, endIdx) ->
-                binding.EnterBody.highlight(startIdx, endIdx, false)
-            }
+        binding.EnterBody.highlight(occurrences, -1)
+        searchResultIndices = occurrences
         return searchResultIndices!!.size
     }
 
@@ -124,7 +122,7 @@ class EditTextPlainActivity : EditActivity(Type.NOTE) {
             return
         }
         searchResultIndices?.get(resultPos)?.let { (startIdx, endIdx) ->
-            val selectedLineTop = binding.EnterBody.highlight(startIdx, endIdx, true)
+            val selectedLineTop = binding.EnterBody.select(startIdx, endIdx)
             selectedLineTop?.let { binding.ScrollView.scrollTo(0, it) }
         }
     }

--- a/app/src/main/java/com/philkes/notallyx/presentation/activity/note/EditTextPlainActivity.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/activity/note/EditTextPlainActivity.kt
@@ -104,13 +104,15 @@ class EditTextPlainActivity : EditActivity(Type.NOTE) {
         }
     }
 
-    override fun highlightSearchResults(search: String): Int {
+    override suspend fun highlightSearchResults(search: String): Int {
         binding.EnterBody.clearHighlights()
         if (search.isEmpty()) {
             return 0
         }
+        val text = notallyModel.body.toString()
+        val occurrences = withContext(Dispatchers.Default) { text.findAllOccurrences(search) }
         searchResultIndices =
-            notallyModel.body.toString().findAllOccurrences(search).onEach { (startIdx, endIdx) ->
+            occurrences.onEach { (startIdx, endIdx) ->
                 binding.EnterBody.highlight(startIdx, endIdx, false)
             }
         return searchResultIndices!!.size

--- a/app/src/main/java/com/philkes/notallyx/presentation/view/misc/highlightableview/HighlightableEditText.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/view/misc/highlightableview/HighlightableEditText.kt
@@ -9,6 +9,8 @@ import com.philkes.notallyx.presentation.removeSelectionFromSpans
 import com.philkes.notallyx.presentation.view.misc.EditTextWithWatcher
 import com.philkes.notallyx.presentation.withAlpha
 
+private const val SEARCH_HIGHLIGHT_LIMIT = 1_000
+
 /**
  * [AppCompatEditText] whose changes (text edits or span changes) are pushed to [changeHistory].
  * *
@@ -58,31 +60,75 @@ open class HighlightableEditText(context: Context, attrs: AttributeSet) :
     }
 
     /**
-     * Visibly highlight text from [startIdx] to [endIdx]. If [selected] is true the text is
-     * highlighted uniquely. There can only be one [selected] highlight.
-     *
-     * @return Vertical offset to highlighted text line.
+     * Highlights all occurrences and returns the Y-offset of the selected match for scrolling
+     * purposes.
      */
-    fun highlight(startIdx: Int, endIdx: Int, selected: Boolean): Int? {
-        // TODO: Could be replaced with EditText.highlights? (API >= 34)
-        if (selected) {
-            selectedHighlightedSpan?.unselect()
+    fun highlight(newOccurrences: List<Pair<Int, Int>>, selectedIndex: Int = -1) {
+        val editable = text ?: return
+        highlightedSpans.forEach { editable.removeSpan(it) }
+        highlightedSpans.clear()
+        selectedHighlightedSpan = null
+
+        if (newOccurrences.isEmpty()) return
+
+        val nonSelectedColor = highlightColor.withAlpha(0.1f)
+        val selectedColor = highlightColor
+
+        newOccurrences.take(SEARCH_HIGHLIGHT_LIMIT).forEachIndexed { index, (start, end) ->
+            if (start >= 0 && end <= editable.length) {
+                val isSelected = (index == selectedIndex)
+                val span = HighlightSpan(if (isSelected) selectedColor else nonSelectedColor)
+
+                applySpan(span, start, end)
+                highlightedSpans.add(span)
+
+                if (isSelected) {
+                    selectedHighlightedSpan = span
+                }
+            }
         }
-        highlightedSpans
-            .filter { getSpanRange(it) == Pair(startIdx, endIdx) }
-            .forEach {
-                removeSpan(it)
+    }
+
+    /**
+     * Updates the selection state for a specific range without redrawing all spans. Returns the
+     * Y-offset of the newly selected range.
+     */
+    fun select(startIdx: Int, endIdx: Int): Int? {
+        val editable = text ?: return null
+        // 1. Revert the previous selection to a normal highlight
+        selectedHighlightedSpan?.let { oldSpan ->
+            val oldStart = editable.getSpanStart(oldSpan)
+            val oldEnd = editable.getSpanEnd(oldSpan)
+
+            if (oldStart != -1 && oldEnd != -1) {
+                editable.removeSpan(oldSpan)
+                val dimmedSpan = HighlightSpan(highlightColor.withAlpha(0.1f))
+                editable.setSpan(dimmedSpan, oldStart, oldEnd, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+                highlightedSpans.add(dimmedSpan)
+            }
+        }
+
+        // 2. Find and upgrade the span at the new indices
+        // We look for any existing HighlightSpan at this exact location to "upgrade" it
+        val existingSpans = editable.getSpans(startIdx, endIdx, HighlightSpan::class.java)
+        existingSpans.forEach {
+            if (editable.getSpanStart(it) == startIdx && editable.getSpanEnd(it) == endIdx) {
+                editable.removeSpan(it)
                 highlightedSpans.remove(it)
             }
-        val span = HighlightSpan(if (selected) highlightColor else highlightColor.withAlpha(0.1f))
-        applySpan(span, startIdx, endIdx)
-        highlightedSpans.add(span)
-        if (selected) {
-            selectedHighlightedSpan = span
         }
+
+        // 3. Create and apply the new "Selected" span
+        val newSelectedSpan = HighlightSpan(highlightColor)
+        editable.setSpan(newSelectedSpan, startIdx, endIdx, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+
+        selectedHighlightedSpan = newSelectedSpan
+        highlightedSpans.add(newSelectedSpan)
+
+        // 4. Return Y-position for scrolling
         return layout?.let {
-            val line = layout.getLineForOffset(startIdx)
-            layout.getLineTop(line)
+            val line = it.getLineForOffset(startIdx)
+            it.getLineTop(line)
         }
     }
 
@@ -94,7 +140,7 @@ open class HighlightableEditText(context: Context, attrs: AttributeSet) :
         val (previousHighlightedStartIdx, previousHighlightedEndIdx) = getSpanRange(this)
         if (previousHighlightedStartIdx != -1) {
             removeSpan(this)
-            highlight(previousHighlightedStartIdx, previousHighlightedEndIdx, false)
+            highlight(listOf(Pair(previousHighlightedStartIdx, previousHighlightedEndIdx)), -1)
         }
     }
 }

--- a/app/src/main/java/com/philkes/notallyx/presentation/view/note/listitem/adapter/ListItemVH.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/view/note/listitem/adapter/ListItemVH.kt
@@ -113,11 +113,17 @@ class ListItemVH(
         }
 
         highlights?.let {
-            it.forEach { highlight ->
-                binding.EditText.highlight(highlight.startIdx, highlight.endIdx, highlight.selected)
-            }
+            var selected: ListItemHighlight? = null
+            val pairs =
+                highlights.map { highlight ->
+                    if (highlight.selected) {
+                        selected = highlight
+                    }
+                    Pair(highlight.startIdx, highlight.endIdx)
+                }
+            binding.EditText.highlight(pairs, -1)
+            selected?.let { binding.EditText.select(it.startIdx, it.endIdx) }
         } ?: binding.EditText.clearHighlights()
-
         binding.root.setControlsContrastColorForAllViews(backgroundColor)
     }
 

--- a/app/src/main/java/com/philkes/notallyx/presentation/view/note/listitem/adapter/ListItemVH.kt
+++ b/app/src/main/java/com/philkes/notallyx/presentation/view/note/listitem/adapter/ListItemVH.kt
@@ -123,7 +123,7 @@ class ListItemVH(
                 }
             binding.EditText.highlight(pairs, -1)
             selected?.let { binding.EditText.select(it.startIdx, it.endIdx) }
-        } ?: binding.EditText.clearHighlights()
+        }
         binding.root.setControlsContrastColorForAllViews(backgroundColor)
     }
 

--- a/app/src/main/java/com/philkes/notallyx/utils/MiscExtensions.kt
+++ b/app/src/main/java/com/philkes/notallyx/utils/MiscExtensions.kt
@@ -56,12 +56,20 @@ fun String.findAllOccurrences(
     search: String,
     caseSensitive: Boolean = false,
 ): List<Pair<Int, Int>> {
+    val limit = 20_000
     if (search.isEmpty()) return emptyList()
-    val regex = Regex(Regex.escape(if (caseSensitive) search else search.lowercase()))
-    return regex
-        .findAll(if (caseSensitive) this else this.lowercase())
-        .map { match -> match.range.first to match.range.last + 1 }
-        .toList()
+    val result = mutableListOf<Pair<Int, Int>>()
+    var startIndex = 0
+    while (startIndex < length) {
+        // use ignoreCase parameter to avoid creating a new lowercased string
+        val index = this.indexOf(search, startIndex, ignoreCase = !caseSensitive)
+        if (index == -1) break
+        result.add(index to (index + search.length))
+        if (result.size >= limit) break
+        // Move pointer forward
+        startIndex = index + search.length
+    }
+    return result
 }
 
 fun String.removeTrailingParentheses(): String {

--- a/app/src/main/java/com/philkes/notallyx/utils/SortedListExtensions.kt
+++ b/app/src/main/java/com/philkes/notallyx/utils/SortedListExtensions.kt
@@ -11,11 +11,13 @@ fun <R, C> SortedList<R>.mapIndexed(transform: (Int, R) -> C): List<C> {
 }
 
 suspend fun <R, C> SortedList<R>.mapIndexedSuspended(transform: suspend (Int, R) -> C): List<C> {
-    return (0 until this.size()).mapIndexed { idx, it -> transform.invoke(idx, this[it]) }
+    val snapshot = List(size()) { index -> this[index] }
+    return snapshot.mapIndexed { idx, item -> transform(idx, item) }
 }
 
 suspend fun <R, C> List<R>.mapIndexedSuspended(transform: suspend (Int, R) -> C): List<C> {
-    return mapIndexed { idx, it -> transform.invoke(idx, this[idx]) }
+    val snapshot = toList()
+    return snapshot.mapIndexed { idx, item -> transform(idx, item) }
 }
 
 fun <R> SortedList<R>.forEach(function: (item: R) -> Unit) {

--- a/app/src/main/java/com/philkes/notallyx/utils/SortedListExtensions.kt
+++ b/app/src/main/java/com/philkes/notallyx/utils/SortedListExtensions.kt
@@ -10,6 +10,14 @@ fun <R, C> SortedList<R>.mapIndexed(transform: (Int, R) -> C): List<C> {
     return (0 until this.size()).mapIndexed { idx, it -> transform.invoke(idx, this[it]) }
 }
 
+suspend fun <R, C> SortedList<R>.mapIndexedSuspended(transform: suspend (Int, R) -> C): List<C> {
+    return (0 until this.size()).mapIndexed { idx, it -> transform.invoke(idx, this[it]) }
+}
+
+suspend fun <R, C> List<R>.mapIndexedSuspended(transform: suspend (Int, R) -> C): List<C> {
+    return mapIndexed { idx, it -> transform.invoke(idx, this[idx]) }
+}
+
 fun <R> SortedList<R>.forEach(function: (item: R) -> Unit) {
     return (0 until this.size()).forEach { function.invoke(this[it]) }
 }


### PR DESCRIPTION
Fixes #1033 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Search highlighting now runs asynchronously, cancels prior in-flight highlights, and avoids redundant retriggers for smoother, more responsive searching.

* **New Features**
  * Jump-to-match selection reliably scrolls and positions the cursor when navigating results.
  * Highlights are capped to a safe limit to prevent UI overload and improve performance on large notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->